### PR TITLE
Add initial Week 4 Node schedule

### DIFF
--- a/week-4/schedule.md
+++ b/week-4/schedule.md
@@ -1,4 +1,4 @@
-# Testing Week Schedule
+# Node Week Schedule
 
 ## Day 1
 

--- a/week-4/schedule.md
+++ b/week-4/schedule.md
@@ -1,0 +1,64 @@
+# Testing Week Schedule
+
+## Day 1
+
+| Time    | Activity                                    | Learning outcomes                      |
+| ------- | ------------------------------------------- | -------------------------------------- |
+| 09:45   | Intro reading                               | Web servers                            |
+| 10:00   | Intro presentation                          |                                        |
+| 10:30   | [Node intro](node-intro) tbc                | HTTP server                            |
+| 11:00   | [Node Girls workshop](node-girls)           | HTTP server, POST requests, HTML forms |
+| _13:00_ | _Lunch_                                     |                                        |
+| 14:00   | [Node Girls workshop](node-girls) continued | Testing                                |
+| 16:00   | Tech for Better                             |                                        |
+
+[node-intro]: tbc
+[node-girls]: https://github.com/node-girls/node-workshop/
+
+## Day 2
+
+| Time    | Activity                           | Learning outcomes    |
+| ------- | ---------------------------------- | -------------------- |
+| 09:45   | Intro reading                      |                      |
+| 10:00   | [Design burst: navigation](db-nav) |                      |
+| 10:30   | Navigation workshop tbc            | Hover & focus styles |
+| 11:00   | [TDD Node Server](node-tdd)        | Tape, TDD            |
+| _13:00_ | _Lunch_                            |                      |
+| 14:00   | Project intro                      |                      |
+| 14:30   | Technical spikes                   |                      |
+| 16:30   | Spike presentation prep            |                      |
+| 17:00   | Spike presentations                |                      |
+
+[db-nav]: https://docs.google.com/presentation/d/1Qus1BOmpF-3rMBiulsyUf0YVPgubFHzmH9tcu6wrc9A/edit#slide=id.g26a95a14fb_0_0
+[node-tdd]: https://github.com/foundersandcoders/ws-tdd-node-server
+
+## Day 3
+
+| Time    | Activity      | Learning outcomes        |
+| ------- | ------------- | ------------------------ |
+| 09:45   | Intro reading |                          |
+| 10:00   | Node fetch MC | Network requests in Node |
+| 11:00   | Project       |                          |
+| _13:00_ | _Lunch_       |                          |
+| 14:00   | Project       |                          |
+| 17:00   | Speaker       |                          |
+
+## Day 4
+
+| Time    | Activity |
+| ------- | -------- |
+| 09:45   | Project  |
+| _13:00_ | _Lunch_  |
+| 14:00   | Project  |
+
+## Day 5
+
+| Time  | Activity          |
+| ----- | ----------------- |
+| 09:45 | Code review       |
+| 11:00 | Respond to issues |
+| 12:30 | Presentation prep |
+| 13:00 | _Lunch_           |
+| 14:00 | Presentations     |
+| 16:00 | Stop Go Continues |
+| 17:00 | Speaker           |

--- a/week-4/schedule.md
+++ b/week-4/schedule.md
@@ -34,14 +34,16 @@
 
 ## Day 3
 
-| Time    | Activity      | Learning outcomes        |
-| ------- | ------------- | ------------------------ |
-| 09:45   | Intro reading |                          |
-| 10:00   | Node fetch MC | Network requests in Node |
-| 11:00   | Project       |                          |
-| _13:00_ | _Lunch_       |                          |
-| 14:00   | Project       |                          |
-| 17:00   | Speaker       |                          |
+| Time    | Activity                  | Learning outcomes        |
+| ------- | ------------------------- | ------------------------ |
+| 09:45   | Intro reading             |                          |
+| 10:00   | [Node fetch MC](fetch-mc) | Network requests in Node |
+| 11:00   | Project                   |                          |
+| _13:00_ | _Lunch_                   |                          |
+| 14:00   | Project                   |                          |
+| 17:00   | Speaker                   |                          |
+
+[fetch-mc]: https://github.com/foundersandcoders/mc-request-module-workshop
 
 ## Day 4
 


### PR DESCRIPTION
Matches the general structure of the Week 3 schedule:

1. Day 1: general week intro, leading into more complex workshop
1. Day 2: design burst, then another more specific workshop
1. Day 3: morning challenge on stuff they might need in their project