### PR TITLE
Add Week 8 schedule

### DIFF
--- a/week-8/schedule.md
+++ b/week-8/schedule.md
@@ -1,0 +1,60 @@
+# Full stack app Week Schedule
+
+## Day 1
+
+| Time    | Activity           | Learning outcomes |
+| ------- | ------------------ | ----------------- |
+| 09:45   | Intro reading      |                   |
+| 10:00   | Intro presentation |                   |
+| 10:30   |                    |                   |
+| 11:00   |                    |                   |
+| _13:00_ | _Lunch_            |                   |
+| 14:00   |                    |                   |
+| 16:00   | Tech for Better    |                   |
+
+[testing-lib]: https://github.com/oliverjam/learn-testing/
+
+## Day 2
+
+| Time    | Activity                 | Learning outcomes |
+| ------- | ------------------------ | ----------------- |
+| 09:45   | Intro reading            |                   |
+| 10:00   | Design burst: loading    |                   |
+| 10:30   | Loading spinner workshop | a11y, animation   |
+| 11:00   |                          |                   |
+| _13:00_ | _Lunch_                  |                   |
+| 14:00   | Project intro            |                   |
+| 14:30   | Technical spikes         |                   |
+| 16:30   | Spike presentation prep  |                   |
+| 17:00   | Spike presentations      |                   |
+
+## Day 3
+
+| Time    | Activity        | Learning outcomes        |
+| ------- | --------------- | ------------------------ |
+| 09:45   | Intro reading   |                          |
+| 10:00   | Test mocking MC | Mocking network requests |
+| 11:00   | Project         |                          |
+| _13:00_ | _Lunch_         |                          |
+| 14:00   | Project         |                          |
+| 17:00   | Speaker         |                          |
+
+## Day 4
+
+| Time    | Activity |
+| ------- | -------- |
+| 09:45   | Project  |
+| _13:00_ | _Lunch_  |
+| 14:00   | Project  |
+
+## Day 5
+
+| Time  | Activity          |
+| ----- | ----------------- |
+| 09:45 | Code review       |
+| 11:00 | Respond to issues |
+| 12:30 | Presentation prep |
+| 13:00 | _Lunch_           |
+| 14:00 | Presentations     |
+| 16:00 | Stop Go Continues |
+| 17:00 | Speaker           |

--- a/week-8/schedule.md
+++ b/week-8/schedule.md
@@ -2,31 +2,29 @@
 
 ## Day 1
 
-| Time    | Activity           | Learning outcomes |
-| ------- | ------------------ | ----------------- |
-| 09:45   | Intro reading      |                   |
-| 10:00   | Intro presentation |                   |
-| 10:30   |                    |                   |
-| 11:00   |                    |                   |
-| _13:00_ | _Lunch_            |                   |
-| 14:00   |                    |                   |
-| 16:00   | Tech for Better    |                   |
-
-[testing-lib]: https://github.com/oliverjam/learn-testing/
+| Time    | Activity              | Learning outcomes           |
+| ------- | --------------------- | --------------------------- |
+| 09:45   | Intro reading         |                             |
+| 10:00   | Intro presentation    |                             |
+| 10:30   | Intro to ES Modules   | Native JS modules           |
+| 11:00   | Client-side rendering | innerHTML, Template element |
+| _13:00_ | _Lunch_               |                             |
+| 14:00   | Client-side routing   | Routing, History API        |
+| 16:00   | Tech for Better       |                             |
 
 ## Day 2
 
-| Time    | Activity                 | Learning outcomes |
-| ------- | ------------------------ | ----------------- |
-| 09:45   | Intro reading            |                   |
-| 10:00   | Design burst: loading    |                   |
-| 10:30   | Loading spinner workshop | a11y, animation   |
-| 11:00   |                          |                   |
-| _13:00_ | _Lunch_                  |                   |
-| 14:00   | Project intro            |                   |
-| 14:30   | Technical spikes         |                   |
-| 16:30   | Spike presentation prep  |                   |
-| 17:00   | Spike presentations      |                   |
+| Time    | Activity                 | Learning outcomes                 |
+| ------- | ------------------------ | --------------------------------- |
+| 09:45   | Intro reading            |                                   |
+| 10:00   | Design burst: loading    |                                   |
+| 10:30   | Loading spinner workshop | a11y, animation                   |
+| 11:00   | Error handling workshop  | Error handling, User notification |
+| _13:00_ | _Lunch_                  |                                   |
+| 14:00   | Project intro            |                                   |
+| 14:30   | Technical spikes         |                                   |
+| 16:30   | Spike presentation prep  |                                   |
+| 17:00   | Spike presentations      |                                   |
 
 ## Day 3
 


### PR DESCRIPTION
I've moved mocking from Week 7 MC to here since it's a better fit (they should be testing this frontend without worrying about the separate backend, which should already have tests)

Since this week is mostly stuff they already know the basics of I figured we could teach some more interesting client-side stuff. So I've added both ES Modules and basic client-side routing, both of which will make their projects easier and more realistic.

Let me know if you think that's too much new/weird stuff!