### PR TITLE
Add a generic schedule for weeks1-8 alongside a table of topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ The new coursebook
 
 ## Topics
 
-| Week | Topic                |
-| ---- | -------------------- |
-| 1    | Teamwork and Toolkit |
-| 2    | HTTP                 |
-| 3    | Testing              |
-| 4    | Node                 |
-| 5    | Databases            |
-| 6    | Authentication       |
-| 7    | REST APIs            |
-| 8    | Full-Stack App       |
+| Week | Topic                            |
+| ---- | -------------------------------- |
+| 1    | [Teamwork and Toolkit](./week-1) |
+| 2    | [HTTP](./week-2)                 |
+| 3    | [Testing](./week-3)              |
+| 4    | [Node](./week-4)                 |
+| 5    | [Databases](./week-5)            |
+| 6    | [Authentication](./week-6)       |
+| 7    | [REST APIs](./week-7)            |
+| 8    | [Full-Stack App](./week-8)       |
 
 ## Default Schedule
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,81 @@
 # coursebook
+
 The new coursebook
+
+## Topics
+
+| Week | Topic                |
+| ---- | -------------------- |
+| 1    | Teamwork and Toolkit |
+| 2    | HTTP                 |
+| 3    | Testing              |
+| 4    | Node                 |
+| 5    | Databases            |
+| 6    | Authentication       |
+| 7    | REST APIs            |
+| 8    | Full-Stack App       |
+
+## Default Schedule
+
+The general timetable for the first 8 weeks. This does differ from week to week - see each week's schedule for specific schedules.
+
+### Day 1
+
+| Time    | Activity           | Description                                    |
+| ------- | ------------------ | ---------------------------------------------- |
+| 09:45   | Intro Reading      | Reading around this week's topic               |
+| 10:00   | Intro Presentation | Mentors present on this week's topic           |
+| 10:30   | Workshops          |                                                |
+| _13:00_ | _Lunch_            |                                                |
+| 14:00   | Workshop           |                                                |
+| 16:00   | Tech for Better    | Workshops as part of Tech for Better programme |
+| _18:00_ | _Finish_           |                                                |
+
+### Day 2
+
+| Time    | Activity                | Description                                                  |
+| ------- | ----------------------- | ------------------------------------------------------------ |
+| 09:45   | Intro Reading           |                                                              |
+| 10:00   | Design Burst            | A short presentation on an aspect of design                  |
+| 10:30   | Design Workshop         | A follow-on workshop on the design topic                     |
+| 11:00   | Workshop                |                                                              |
+| _13:00_ | _Lunch_                 |                                                              |
+| 14: 00  | Project intro           | Mentors will introduce the project and its learning outcomes |
+| 14:30   | Technical Spikes        | Research into a technical topic you'll need this week        |
+| 16:30   | Spike Presentation Prep |                                                              |
+| 17:00   | Spike Presentations     |                                                              |
+| _18:00_ | _Finish_                |                                                              |
+
+### Day 3
+
+| Time    | Activity          | Description                                                     |
+| ------- | ----------------- | --------------------------------------------------------------- |
+| 09:45   | Intro Reading     |                                                                 |
+| 10:00   | Morning Challenge | A workshop to challenge your understanding of this week's topic |
+| 11:00   | Project           |                                                                 |
+| _13:00_ | _Lunch_           |                                                                 |
+| 14:00   | Project           |                                                                 |
+| 17:00   | Speaker           | A technical talk from an employment partner or FAC alum         |
+| _18:00_ | _Finish_          |                                                                 |
+
+### Day 4
+
+| Time    | Activity | Description |
+| ------- | -------- | ----------- |
+| 09:45   | Project  |             |
+| _13:00_ | _Lunch_  |             |
+| 14:00   | Project  |             |
+| _18:00_ | _Finish_ |             |
+
+### Day 5
+
+| Time    | Activity            | Description                                                                |
+| ------- | ------------------- | -------------------------------------------------------------------------- |
+| 09:45   | Code Review         | Review another team's project code                                         |
+| 11:00   | Respond to issues   | Refactor your project based upon the feedback you got in code review       |
+| 12:30   | Presentation Prep   |                                                                            |
+| _13:00_ | _Lunch_             |                                                                            |
+| 14:00   | Presentations       | Present your project from this week                                        |
+| 16:00   | Stop, Go, Continues | Cohort and team retrospectives                                             |
+| 17:00   | Speaker             | A talk about careers and employment from an employment partner or FAC alum |
+| _18:00_ | _Finish_            |                                                                            |


### PR DESCRIPTION
Adding in the generic schedule that we can present to FAC18 alongside a list of topics for each week. 