### PR TITLE
Add about page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,127 +1,19 @@
-# Founders and Coders Curriculum
+# FAC Curriculum
 
-Welcome to our curriculum. This material forms the basis of our tuition-free, peer-led web development programme.
+This repo contains the source code and content for our open-source curriculum: learn.foundersandcoders.com.
 
-## Using our curriculum
+To learn more about the curriculum, including whether you're allowed to use it, please read the curriculum's [about page](https://learn.foundersandcoders.com/about/).
 
-Our curriculum is open source and free to use. This means anyone is welcome to work through the material at their own pace, even if they don't have a place on one of our bootcamp cohorts.
+## Running locally
 
-If you do decide to use our material please let us know. We can only accept so many people onto our program so we'd love to hear about others benefiting from our work. You could also join our Slack community to help and be helped by other people learning to code.
+This site is built using the [Eleventy](https://11ty.dev/) static site generator. It requires Git, Node and npm installed on your machine to start.
 
-Although we love people using our curriculum to self-learn we have to ask that you **do not claim to have attended or completed Founders and Coders**.
+1. Clone this repo
+1. Run `npm install` to install all the required dependencies
+1. Run `npm run dev` to start an auto-reloading development server
 
-### License
+Alternatively run `npm run build` to create the final production `_site` directory. You can serve this with any web server as it's just static HTML, CSS and JS.
 
-The work is available under the Creative Commons [Attribution-NonCommercial-ShareAlike](https://creativecommons.org/licenses/by-nc-sa/4.0/) license. This means you can share or adapt the material as you like, as long as you:
+### Git hooks
 
-1. Give us credit for creating it
-1. Maintain the original license
-1. Continue to offer it free of charge
-
-#### What you can do
-
-1. Work through the material yourself, or in groups of like-minded people
-1. [Clone](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository) the workshop repos to work on them locally
-1. [Fork](https://guides.github.com/activities/forking/) the workshop repos so you have a copy on your own GitHub account
-
-#### What you _cannot_ do
-
-1. Create your own copy of the curriculum with our license removed
-1. Create your own copies of the workshops by pasting our material into a new repo
-1. Any other activity that removes attribution or authorship history
-
-## Topics
-
-| Week | Topic                                                                                                              |
-| ---- | ------------------------------------------------------------------------------------------------------------------ |
-| 1    | [Teamwork and Toolkit](https://founders-and-coders.gitbook.io/coursebook/curriculum/teamwork-and-toolkit/schedule) |
-| 2    | [HTTP](https://founders-and-coders.gitbook.io/coursebook/curriculum/http/schedule)                                 |
-| 3    | [Testing](https://founders-and-coders.gitbook.io/coursebook/curriculum/testing/schedule)                           |
-| 4    | [Node](https://founders-and-coders.gitbook.io/coursebook/curriculum/node/schedule)                                 |
-| 5    | [Databases](https://founders-and-coders.gitbook.io/coursebook/curriculum/databases/schedule)                       |
-| 6    | [Authentication](https://founders-and-coders.gitbook.io/coursebook/curriculum/authentication/schedule)             |
-| 7    | [REST APIs](https://founders-and-coders.gitbook.io/coursebook/curriculum/rest-apis/schedule)                       |
-| 8    | [Single Page Apps](https://founders-and-coders.gitbook.io/coursebook/curriculum/single-page-app/schedule)          |
-| 9    | [React](https://founders-and-coders.gitbook.io/coursebook/curriculum/react/schedule)                               |
-
-## Default Schedule
-
-The timetable can differ from week to week. See each week's schedule for details. There is usually an additional reading week after Week 7 or 8.
-
-### Day 1
-
-| Time    | Activity                | Description                                 |
-| ------- | ----------------------- | ------------------------------------------- |
-| 09:45   | Mentors intro           | Mentors introduce themselves                |
-| 09:50   | Check-in                |                                             |
-| 10:00   | Feedback on last week   | Airtable online survey                      |
-| 10:05   | Intro presentation      | Mentors present on this week's topic        |
-| 10:20   | Intro workshop          | Short introductory workshop                 |
-| 11:00   | Workshop                | The first of four 2-hour workshops          |
-| _13:00_ | _Lunch_                 |                                             |
-| 14:00   | Workshop                |                                             |
-| 16:00   | Project and spike intro | Introduce the project and learning outcomes |
-| 16:15   | Technical spike         | Research a relevant topic                   |
-| 17:15   | Presentation prep       | Prepare spike presentation                  |
-| 17:45   | Check-out               |                                             |
-| _18:00_ | _Finish_                |                                             |
-
-### Day 2
-
-| Time    | Activity            | Description                                             |
-| ------- | ------------------- | ------------------------------------------------------- |
-| 09:45   | Check-in            |                                                         |
-| 10:00   | Presentation prep   |                                                         |
-| 10:10   | Spike presentations |                                                         |
-| 11:00   | Workshop            |                                                         |
-| _13:00_ | _Lunch_             |                                                         |
-| 14:00   | Workshop            |                                                         |
-| 16:00   | Tech for Better     |                                                         |
-| 17:00   | Speaker             | A technical talk from an employment partner or FAC alum |
-| 17:45   | Check-out           |                                                         |
-| _18:00_ | _Finish_            |                                                         |
-
-### Day 3
-
-| Time    | Activity             | Description                                                     |
-| ------- | -------------------- | --------------------------------------------------------------- |
-| 09:45   | Check-in             |                                                                 |
-| 10:00   | Morning Challenge    | A workshop to challenge your understanding of this week's topic |
-| 11:00   | Project              |                                                                 |
-| 12:45   | Role circles         |                                                                 |
-| _13:00_ | _Lunch_              |                                                                 |
-| 14:00   | Project              | Discussions held with potential Tech for Better partners        |
-| 15:30   | Employment prep      | Portfolio, CV, media presence and interview prep (weeks 5+)     |
-| 16:30   | Community engagement |                                                                 |
-| 17:45   | Check-out            |                                                                 |
-| _18:00_ | _Finish_             |                                                                 |
-
-### Day 4
-
-| Time    | Activity  | Description |
-| ------- | --------- | ----------- |
-| 09:45   | Check-in  |             |
-| 10:00   | Project   |             |
-| _13:00_ | _Lunch_   |             |
-| 14:00   | Project   |             |
-| 17:15   | Code Q&A  |
-| 17:45   | Check-out |             |
-| _18:00_ | _Finish_  |             |
-
-### Day 5
-
-| Time    | Activity            | Description                                                          |
-| ------- | ------------------- | -------------------------------------------------------------------- |
-| 09:45   | Check-in            |                                                                      |
-| 10:00   | Code Review         | Review another team's project code                                   |
-| 11:00   | Respond to issues   | Refactor your project based upon the feedback you got in code review |
-| 12:00   | Role circles        |                                                                      |
-| 12:15   | Presentation prep   |                                                                      |
-| _13:00_ | _Lunch_             |                                                                      |
-| 14:00   | Presentations       | Present your project from this week                                  |
-| 15:15   | Stop, Go, Continue  | Cohort retrospective                                                 |
-| 16:00   | Team SGCs           | Project team retrospectives                                          |
-| 16:45   | Update user manuals |                                                                      |
-| 17:00   | Speaker             | A talk from an employment partner or FAC alum                        |
-| 17:45   | Check-out           |                                                                      |
-| _18:00_ | _Finish_            |                                                                      |
+This package installs a custom pre-commit Git hook when you `npm install`. This hook automatically formats your changes using Prettier (with the default settings). This ensures all files have consistent style and formatting. So don't be surprised if you see things move around a bit after you commit a change.

--- a/src/_data/eleventyComputed.js
+++ b/src/_data/eleventyComputed.js
@@ -1,15 +1,4 @@
 module.exports = {
-  permalink: (data) => {
-    // README.md should always be the homepage
-    // this is so we can avoid having frontmatter in the readme
-    // since this would show up on GitHub and look weird
-    // https://www.11ty.dev/docs/data-computed/
-    if (data.page.fileSlug === "README") {
-      return "/about/index.html";
-    } else {
-      return data.permalink;
-    }
-  },
   layout: (data) => {
     if (data.page.url.includes("starter-files")) return false;
     if (data.layout) return data.layout;

--- a/src/about.md
+++ b/src/about.md
@@ -1,0 +1,131 @@
+---
+title: About our curriculum
+---
+
+# About our curriculum
+
+Welcome to our curriculum. This material forms the basis of our tuition-free, peer-led web development programme.
+
+## Using our curriculum
+
+Our curriculum is open source and free to use. This means anyone is welcome to work through the material at their own pace, even if they don't have a place on one of our bootcamp cohorts.
+
+If you do decide to use our material please let us know. We can only accept so many people onto our program so we'd love to hear about others benefiting from our work. You could also join our Slack community to help and be helped by other people learning to code.
+
+Although we love people using our curriculum to self-learn we have to ask that you **do not claim to have attended or completed Founders and Coders**.
+
+### License
+
+The work is available under the Creative Commons [Attribution-NonCommercial-ShareAlike](https://creativecommons.org/licenses/by-nc-sa/4.0/) license. This means you can share or adapt the material as you like, as long as you:
+
+1. Give us credit for creating it
+1. Maintain the original license
+1. Continue to offer it free of charge
+
+#### What you can do
+
+1. Work through the material yourself, or in groups of like-minded people
+1. [Clone](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository) the workshop repos to work on them locally
+1. [Fork](https://guides.github.com/activities/forking/) the workshop repos so you have a copy on your own GitHub account
+
+#### What you _cannot_ do
+
+1. Create your own copy of the curriculum with our license removed
+1. Create your own copies of the workshops by pasting our material into a new repo
+1. Any other activity that removes attribution or authorship history
+
+## Topics
+
+| Week | Topic                                                                                                              |
+| ---- | ------------------------------------------------------------------------------------------------------------------ |
+| 1    | [Teamwork and Toolkit](https://founders-and-coders.gitbook.io/coursebook/curriculum/teamwork-and-toolkit/schedule) |
+| 2    | [HTTP](https://founders-and-coders.gitbook.io/coursebook/curriculum/http/schedule)                                 |
+| 3    | [Testing](https://founders-and-coders.gitbook.io/coursebook/curriculum/testing/schedule)                           |
+| 4    | [Node](https://founders-and-coders.gitbook.io/coursebook/curriculum/node/schedule)                                 |
+| 5    | [Databases](https://founders-and-coders.gitbook.io/coursebook/curriculum/databases/schedule)                       |
+| 6    | [Authentication](https://founders-and-coders.gitbook.io/coursebook/curriculum/authentication/schedule)             |
+| 7    | [REST APIs](https://founders-and-coders.gitbook.io/coursebook/curriculum/rest-apis/schedule)                       |
+| 8    | [Single Page Apps](https://founders-and-coders.gitbook.io/coursebook/curriculum/single-page-app/schedule)          |
+| 9    | [React](https://founders-and-coders.gitbook.io/coursebook/curriculum/react/schedule)                               |
+
+## Default Schedule
+
+The timetable can differ from week to week. See each week's schedule for details. There is usually an additional reading week after Week 7 or 8.
+
+### Day 1
+
+| Time    | Activity                | Description                                 |
+| ------- | ----------------------- | ------------------------------------------- |
+| 09:45   | Mentors intro           | Mentors introduce themselves                |
+| 09:50   | Check-in                |                                             |
+| 10:00   | Feedback on last week   | Airtable online survey                      |
+| 10:05   | Intro presentation      | Mentors present on this week's topic        |
+| 10:20   | Intro workshop          | Short introductory workshop                 |
+| 11:00   | Workshop                | The first of four 2-hour workshops          |
+| _13:00_ | _Lunch_                 |                                             |
+| 14:00   | Workshop                |                                             |
+| 16:00   | Project and spike intro | Introduce the project and learning outcomes |
+| 16:15   | Technical spike         | Research a relevant topic                   |
+| 17:15   | Presentation prep       | Prepare spike presentation                  |
+| 17:45   | Check-out               |                                             |
+| _18:00_ | _Finish_                |                                             |
+
+### Day 2
+
+| Time    | Activity            | Description                                             |
+| ------- | ------------------- | ------------------------------------------------------- |
+| 09:45   | Check-in            |                                                         |
+| 10:00   | Presentation prep   |                                                         |
+| 10:10   | Spike presentations |                                                         |
+| 11:00   | Workshop            |                                                         |
+| _13:00_ | _Lunch_             |                                                         |
+| 14:00   | Workshop            |                                                         |
+| 16:00   | Tech for Better     |                                                         |
+| 17:00   | Speaker             | A technical talk from an employment partner or FAC alum |
+| 17:45   | Check-out           |                                                         |
+| _18:00_ | _Finish_            |                                                         |
+
+### Day 3
+
+| Time    | Activity             | Description                                                     |
+| ------- | -------------------- | --------------------------------------------------------------- |
+| 09:45   | Check-in             |                                                                 |
+| 10:00   | Morning Challenge    | A workshop to challenge your understanding of this week's topic |
+| 11:00   | Project              |                                                                 |
+| 12:45   | Role circles         |                                                                 |
+| _13:00_ | _Lunch_              |                                                                 |
+| 14:00   | Project              | Discussions held with potential Tech for Better partners        |
+| 15:30   | Employment prep      | Portfolio, CV, media presence and interview prep (weeks 5+)     |
+| 16:30   | Community engagement |                                                                 |
+| 17:45   | Check-out            |                                                                 |
+| _18:00_ | _Finish_             |                                                                 |
+
+### Day 4
+
+| Time    | Activity  | Description |
+| ------- | --------- | ----------- |
+| 09:45   | Check-in  |             |
+| 10:00   | Project   |             |
+| _13:00_ | _Lunch_   |             |
+| 14:00   | Project   |             |
+| 17:15   | Code Q&A  |
+| 17:45   | Check-out |             |
+| _18:00_ | _Finish_  |             |
+
+### Day 5
+
+| Time    | Activity            | Description                                                          |
+| ------- | ------------------- | -------------------------------------------------------------------- |
+| 09:45   | Check-in            |                                                                      |
+| 10:00   | Code Review         | Review another team's project code                                   |
+| 11:00   | Respond to issues   | Refactor your project based upon the feedback you got in code review |
+| 12:00   | Role circles        |                                                                      |
+| 12:15   | Presentation prep   |                                                                      |
+| _13:00_ | _Lunch_             |                                                                      |
+| 14:00   | Presentations       | Present your project from this week                                  |
+| 15:15   | Stop, Go, Continue  | Cohort retrospective                                                 |
+| 16:00   | Team SGCs           | Project team retrospectives                                          |
+| 16:45   | Update user manuals |                                                                      |
+| 17:00   | Speaker             | A talk from an employment partner or FAC alum                        |
+| 17:45   | Check-out           |                                                                      |
+| _18:00_ | _Finish_            |                                                                      |


### PR DESCRIPTION
- Move the previous README contents to published `/about/` page.
- Add regular README describing how to run the project etc

I think it makes more sense for the "who can use this?" stuff to be in an actual published page, and for the readme to be reserved for people viewing on GitHub (and so primarily code-related).