### PR TITLE
New schedule format

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,4 +1,4 @@
-const fs = require("fs");
+const yaml = require("js-yaml");
 const markdownIt = require("markdown-it");
 const markdownItAnchor = require("markdown-it-anchor");
 const slugify = require("@sindresorhus/slugify");
@@ -14,6 +14,9 @@ const options = {
 };
 
 module.exports = (config) => {
+  // so we can use yaml to load data as well as json
+  config.addDataExtension("yml", (contents) => yaml.safeLoad(contents));
+
   // re-run the build when source CSS files change
   config.addWatchTarget("src/styles");
   config.addWatchTarget("src/styles/partials");

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "@sindresorhus/slugify": "^1.1.0",
         "cssnano": "^4.1.10",
         "htm": "^3.0.4",
+        "js-yaml": "^3.14.1",
+        "lodash": "^4.17.21",
         "markdown-it": "^11.0.0",
         "markdown-it-anchor": "^5.3.0",
         "markdown-it-task-lists": "^2.1.1",
@@ -4458,9 +4460,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash._reinterpolate": {
       "version": "3.0.0",
@@ -17162,9 +17164,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "@sindresorhus/slugify": "^1.1.0",
     "cssnano": "^4.1.10",
     "htm": "^3.0.4",
+    "js-yaml": "^3.14.1",
+    "lodash": "^4.17.21",
     "markdown-it": "^11.0.0",
     "markdown-it-anchor": "^5.3.0",
     "markdown-it-task-lists": "^2.1.1",

--- a/src/_data/defaultSchedule.yml
+++ b/src/_data/defaultSchedule.yml
@@ -1,0 +1,117 @@
+monday:
+  - start: 9:45
+    end: 10:00
+    name: Check-in
+  - start: 13:00
+    end: 14:00
+    name: Lunch
+  - start: 16:00
+    end: 16:15
+    name: Project & Spikes intro
+  - start: 16:15
+    end: 17:15
+    name: Technical spikes
+    type: spike
+  - start: 17:15
+    end: 17:45
+    name: Spike preparation
+  - start: 17:45
+    end: 18:00
+    name: Check-out
+tuesday:
+  - start: 9:45
+    end: 10:00
+    name: Check-in
+  - start: 10:00
+    end: 10:15
+    name: Spike prep
+  - start: 10:15
+    end: 11:00
+    name: Spike presentations
+    type: presentation
+  - start: 13:00
+    end: 14:00
+    name: Lunch
+  - start: 16:00
+    end: 17:00
+    name: Tech For Better
+  - start: 17:00
+    end: 17:45
+    name: Speaker
+  - start: 17:45
+    end: 18:00
+    name: Check-out
+wednesday:
+  - start: 9:45
+    end: 10:00
+    name: Check-in
+  - start: 11:00
+    end: 13:00
+    name: Project
+    type: project
+  - start: 13:00
+    end: 14:00
+    name: Lunch
+  - start: 14:00
+    end: 17:45
+    name: Project
+    type: project
+  - start: 17:45
+    end: 18:00
+    name: Check-out
+thursday:
+  - start: 9:45
+    end: 10:00
+    name: Check-in
+  - start: 10:00
+    end: 13:00
+    name: Project
+    type: project
+  - start: 13:00
+    end: 14:00
+    name: Lunch
+  - start: 14:00
+    end: 17:45
+    name: Project
+    type: project
+  - start: 17:45
+    end: 18:00
+    name: Check-out
+friday:
+  - start: 9:45
+    end: 10:00
+    name: Check-in
+  - start: 10:00
+    end: 10:45
+    name: Team code review
+  - start: 10:45
+    end: 11:15
+    name: Live code review
+  - start: 11:15
+    end: 12:15
+    name: Respond to issues
+  - start: 12:15
+    end: 13:00
+    name: Presentation prep
+  - start: 13:00
+    end: 14:00
+    name: Lunch
+  - start: 14:00
+    end: 15:15
+    name: Presentations
+    type: presentation
+  - start: 15:15
+    end: 16:00
+    name: Cohort SGC
+  - start: 16:00
+    end: 16:45
+    name: Team SGCs
+  - start: 16:45
+    end: 17:00
+    name: Update user manuals
+  - start: 17:00
+    end: 17:45
+    name: Speaker
+  - start: 17:45
+    end: 18:00
+    name: Check-out

--- a/src/_data/defaultSchedule.yml
+++ b/src/_data/defaultSchedule.yml
@@ -34,7 +34,7 @@ tuesday:
     name: Lunch
   - start: 16:00
     end: 17:00
-    name: Tech For Better
+    name: Interview practice
   - start: 17:00
     end: 17:45
     name: Speaker

--- a/src/_includes/course.11ty.js
+++ b/src/_includes/course.11ty.js
@@ -52,7 +52,7 @@ exports.render = ({ page: { url }, content }) => {
       </${Nav}>
     </aside>
     <main id="main">
-      <${RawContent} class="main-wrapper flow">${content}</${RawContent}>
+      <${RawContent} class="flow">${content}</${RawContent}>
     </main>
   </div>
   `;

--- a/src/_includes/default.11ty.js
+++ b/src/_includes/default.11ty.js
@@ -7,6 +7,6 @@ exports.data = {
 
 exports.render = ({ content }) => {
   return html`
-    <${RawContent} class="main-wrapper flow">${content}</${RawContent}>
+    <${RawContent} class="flow">${content}</${RawContent}>
 `;
 };

--- a/src/_includes/schedule.11ty.js
+++ b/src/_includes/schedule.11ty.js
@@ -1,0 +1,56 @@
+const { html } = require("htm/preact");
+const { mergeWith, unionBy, sortBy } = require("lodash");
+const RawContent = require("./components/RawContent");
+
+exports.data = {
+  layout: "syllabus",
+};
+
+exports.render = ({ defaultSchedule, schedule, content }) => {
+  const finalSchedule = mergeWith(
+    schedule,
+    defaultSchedule,
+    (objValue, srcValue) => {
+      const mergedDay = unionBy(objValue, srcValue, "start");
+      return sortBy(mergedDay, "start");
+    }
+  );
+
+  return html`
+    <dl class="timetable">
+      ${Object.entries(finalSchedule)
+        .map(([weekday, day], i) =>
+          day.map(({ start, end, name, type = "", url }, j) => {
+            const START_TIME = 585;
+            const rowStart = (start - START_TIME) / 15 + 1;
+            const rowEnd = (end - START_TIME) / 15 + 1;
+            const col = `${i + 1} / ${i + 2}`;
+            const row = `${rowStart} / ${rowEnd}`;
+            return html`
+              <div
+                class="entry ${type}"
+                id=${j === 0 && weekday}
+                data-label=${j === 0 && weekday}
+                style="--col: ${col}; --row: ${row}"
+              >
+                <dt>
+                  <span class="day">${weekday} </span>
+                  <span>${formatTime(start)}-${formatTime(end)}</span>
+                </dt>
+                <dd>${url ? html`<a href="${url}">${name}</a>` : name}</dd>
+              </div>
+            `;
+          })
+        )
+        .flat()}
+    </dl>
+  `;
+};
+
+function formatTime(t) {
+  const hours = Math.floor(t / 60);
+  const mins = t % 60;
+  return (
+    hours.toString().padStart(2, "0") + ":" + mins.toString().padStart(2, "0")
+  );
+}

--- a/src/_includes/standalone.11ty.js
+++ b/src/_includes/standalone.11ty.js
@@ -10,7 +10,7 @@ exports.data = {
   layout: "_document",
 };
 
-exports.render = ({ collections, page, content }) => {
+exports.render = ({ content }) => {
   return html`
   <main id="main" class="cover">
     <${RawContent}>${content}</${RawContent}>

--- a/src/_includes/syllabus.11ty.js
+++ b/src/_includes/syllabus.11ty.js
@@ -20,7 +20,7 @@ exports.render = ({ section, topic, page, content }) => {
           <${Tab} page=${page}><!-- href="resources"-->Resources</${Tab}>
         </${Tabs}>
       </header>
-      <${RawContent} class="main-wrapper flow">${content}</${RawContent}>
+      <${RawContent} class="flow">${content}</${RawContent}>
     </div>
 `;
 };

--- a/src/_includes/topics.11ty.js
+++ b/src/_includes/topics.11ty.js
@@ -18,7 +18,7 @@ exports.render = ({ title, page, content }) => {
           <${Tab} page=${page} href="guides">Guides</${Tab}>
         </${Tabs}>
       </header>
-      <${RawContent} class="main-wrapper flow">${content}</${RawContent}>
+      <${RawContent} class="flow">${content}</${RawContent}>
     </div>
 `;
 };

--- a/src/_includes/workshop.11ty.js
+++ b/src/_includes/workshop.11ty.js
@@ -25,7 +25,7 @@ exports.render = ({ title, description, keywords = [], page, content }) => {
       </div>
       <${Copy} ...${page} />
     </header>
-    <${RawContent} style="margin: 4rem 0" class="main-wrapper flow">${content}</${RawContent}>
+    <${RawContent} style="margin: 4rem 0" class="flow">${content}</${RawContent}>
   `;
 };
 

--- a/src/course/syllabus/testing/schedule.md
+++ b/src/course/syllabus/testing/schedule.md
@@ -1,85 +1,39 @@
-## Day 1
-
-| Time    | Activity                                                | Learning outcomes   |
-| ------- | ------------------------------------------------------- | ------------------- |
-| 09:45   | Check-in                                                |                     |
-| 10:00   | [Feedback survey][survey-5]                             |                     |
-| 10:05   | [Intro presentation][testing-intro-25]                  |                     |
-| 10:30   | [Build a testing library][testing-lib-60]               | Testing             |
-| 11:30   | [Unit testing workshop][unit-testing-90]                | Unit testing        |
-| _13:00_ | _Lunch_                                                 |                     |
-| 14:00   | [Integration testing workshop][integration-testing-120] | Integration testing |
-| 16:00   | [Project][project-5] and [spikes][spikes-10] intro      |                     |
-| 16:15   | [Technical spikes][spikes-10]                           |                     |
-| 17:15   | Spike presentation prep                                 |                     |
-| 17:45   | Checkout                                                |                     |
-
-[survey-5]: https://airtable.com/shrIKQyPpx4vSUNzC
-[testing-intro-25]: https://hackmd.io/aDxkr45wTaaDj-ciJSMa4Q
-[testing-lib-60]: https://github.com/oliverjam/learn-testing/
-[unit-testing-90]: https://github.com/oliverjam/learn-unit-testing
-[integration-testing-120]: https://github.com/oliverjam/learn-integration-testing
-[project-5]: https://founders-and-coders.gitbook.io/coursebook/curriculum/testing/project
-[spikes-10]: https://founders-and-coders.gitbook.io/coursebook/curriculum/testing/spikes
-
-## Day 2
-
-| Time    | Activity                                 | Learning outcomes                      |
-| ------- | ---------------------------------------- | -------------------------------------- |
-| 09:45   | Check-in                                 |                                        |
-| 10:00   | Spike presentation prep                  |                                        |
-| 10:10   | Spike presentations                      |                                        |
-| 11:00   | [TDD array methods][tdd-arrays-120]      | Test-Driven-Development, array methods |
-| _13:00_ | _Lunch_                                  |                                        |
-| 14:00   | [Design burst: grids][db-grid-slides-30] | Grid layout, CSS Grid                  |
-| 14:30   | [CSS Grid workshop][db-grid-ws-30]       | Grid layout, CSS Grid                  |
-| 15:00   | Tech for Better - meet FAC19 POs         |                                        |
-| 16:00   | Tech for Better                          |                                        |
-| 17:00   | Speaker                                  |                                        |
-| 17:45   | Checkout                                 |                                        |
-
-[tdd-arrays-120]: https://github.com/oliverjam/tdd-array-methods
-[db-grid-slides-30]: https://hackmd.io/@fac/S1-95B9r8#/
-[db-grid-ws-30]: https://github.com/bobbysebolao/learn-css-grid
-
-## Day 3
-
-| Time    | Activity                                               | Learning outcomes    |
-| ------- | ------------------------------------------------------ | -------------------- |
-| 09:45   | Check-in                                               |                      |
-| 10:00   | [Techniques for generating ideas][generating-ideas-30] | Inspiring creativity |
-| 10:30   | [Scope challenge][scope-mc-60]                         | Scope, closures      |
-| 11:30   | Project                                                |                      |
-| _13:00_ | _Lunch_                                                |                      |
-| 14:00   | Project                                                |                      |
-| 17:45   | Checkout                                               |                      |
-
-[generating-ideas-30]: https://docs.google.com/presentation/d/1Sr3u9F4tl0x9eEssyeLL2tpC8yK8SrpgxcqOKysvpww/edit?usp=sharing
-[scope-mc-60]: https://github.com/oliverjam/js-scope-challenge
-
-## Day 4
-
-| Time    | Activity |
-| ------- | -------- |
-| 09:45   | Check-in |
-| 10:00   | Project  |
-| _13:00_ | _Lunch_  |
-| 14:00   | Project  |
-| 17:45   | Checkout |
-
-## Day 5
-
-| Time  | Activity            |
-| ----- | ------------------- |
-| 09:45 | Check-in            |
-| 10:00 | Team code review    |
-| 10:45 | Live code review    |
-| 11:15 | Respond to issues   |
-| 12:15 | Presentation prep   |
-| 13:00 | _Lunch_             |
-| 14:00 | Presentations       |
-| 15:15 | Cohort SGC          |
-| 16:00 | Team SGCs           |
-| 16:45 | Update user manuals |
-| 17:00 | Roundtable          |
-| 17:45 | Checkout            |
+---
+layout: schedule
+schedule:
+  monday:
+    - start: 10:00
+      end: 10:30
+      name: Intro presentation
+      type: slides
+      url: "/intro-pres"
+    - start: 10:30
+      end: 11:30
+      name: Build a testing library
+      type: workshop
+      url: "/testing-lib"
+    - start: 11:30
+      end: 13:00
+      name: Unit testing
+      type: workshop
+      url: "/intro-pres"
+    - start: 14:00
+      end: 16:00
+      name: Integration testing
+      type: workshop
+      url: "/int-testing"
+  tuesday:
+    - start: 11:00
+      end: 13:00
+      name: TDD Array methods
+      type: workshop
+    - start: 14:00
+      end: 16:00
+      name: Grid design burst
+      type: workshop
+  wednesday:
+    - start: 10:00
+      end: 11:00
+      name: Scope challenge
+      type: challenge
+---

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -6,3 +6,4 @@
 @import "./partials/navigation.css";
 @import "./partials/utilities.css";
 @import "./partials/syntax-highlighting.css";
+@import "./partials/timetable.css";

--- a/src/styles/partials/layout.css
+++ b/src/styles/partials/layout.css
@@ -44,7 +44,7 @@
 }
 
 .center {
-  max-width: var(--measure, 80rem);
+  max-width: var(--measure, 90rem);
   margin-left: auto;
   margin-right: auto;
 }

--- a/src/styles/partials/main.css
+++ b/src/styles/partials/main.css
@@ -46,25 +46,22 @@ main {
   padding: var(--padding);
 }
 
-.main-wrapper {
-  display: grid;
-  grid-template-columns: minmax(0, 65ch) 1fr;
+main p,
+main ul:not([role="list"]),
+main ol:not([role="list"]),
+main blockquote,
+main pre,
+main details,
+main hr {
+  max-width: 46rem;
+}
+
+main p,
+main ul:not([role="list"]),
+main ol:not([role="list"]),
+main blockquote,
+main details {
   line-height: 1.7;
-}
-
-.main-wrapper > * {
-  grid-column: 1 / 2;
-}
-
-/* big stuff can break out to full width */
-.main-wrapper > h1,
-.main-wrapper > header,
-.main-wrapper > table,
-.main-wrapper > img,
-.main-wrapper > figure,
-.main-wrapper > hr,
-.main-wrapper > pre {
-  grid-column: 1 / -1;
 }
 
 table {

--- a/src/styles/partials/navigation.css
+++ b/src/styles/partials/navigation.css
@@ -108,10 +108,10 @@ nav a {
   display: block;
 }
 
-@media (min-width: 40em) {
+@media (min-width: 50em) {
   .layout {
     display: grid;
-    grid-template-columns: 26ch 1fr;
+    grid-template-columns: 25ch minmax(0, 1fr);
   }
 
   .sidebar-nav__toggle {

--- a/src/styles/partials/timetable.css
+++ b/src/styles/partials/timetable.css
@@ -1,0 +1,119 @@
+.timetable {
+  display: grid;
+  row-gap: 0.5rem;
+}
+
+.day {
+  text-transform: capitalize;
+}
+
+.column-label {
+  display: none;
+  justify-self: center;
+  text-transform: uppercase;
+  padding-bottom: 0.5rem;
+}
+
+.entry {
+  --hue: 200;
+  --sat: 20%;
+  display: grid;
+  gap: 0.25rem;
+  align-content: start;
+  border-bottom: 2px solid hsl(var(--hue), var(--sat), 80%);
+  padding: clamp(0.5rem, 0.5rem + 1vw, 1rem);
+  background-color: hsl(var(--hue), var(--sat), 90%);
+  color: hsl(var(--hue), calc(var(--sat) / 4), 15%);
+  line-height: 1.2;
+  transition: transform 0.1s ease-out;
+}
+
+.entry[data-label] {
+  margin-top: 4rem;
+  scroll-margin-top: 4rem;
+  position: relative;
+}
+
+.entry[data-label]:target::after {
+  content: "";
+  position: absolute;
+  top: -2.5rem;
+  left: -1rem;
+  right: -1rem;
+  height: 1000%;
+  z-index: -10;
+  background-image: linear-gradient(var(--bg-800), transparent);
+}
+
+.entry[data-label]::before {
+  content: attr(data-label);
+  text-transform: capitalize;
+  display: block;
+  position: absolute;
+  bottom: calc(100% + 0.5rem);
+  font-weight: bold;
+  font-size: 1.5rem;
+}
+
+.entry.workshop {
+  --hue: 50;
+  --sat: 80%;
+}
+
+.entry.presentation {
+  --hue: 140;
+  --sat: 60%;
+}
+
+.entry.challenge {
+  --hue: 0;
+  --sat: 60%;
+}
+
+.entry.project {
+  --sat: 60%;
+}
+
+.entry dt {
+  font-size: 0.75rem;
+}
+
+.entry dd {
+  font-weight: bold;
+}
+
+.entry a {
+  color: inherit;
+}
+
+@media (min-width: 60rem) {
+  .column-label {
+    display: revert;
+  }
+  .timetable {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    column-gap: clamp(0.025rem, 0.025rem + 2vw, 2rem);
+  }
+  .entry {
+    grid-row: var(--row);
+    grid-column: var(--col);
+    hyphens: auto;
+  }
+  .entry[data-label] {
+    margin-top: 2rem;
+  }
+  .entry[data-label]::before {
+    font-size: 1rem;
+    font-weight: normal;
+    text-align: center;
+    width: 100%;
+  }
+
+  .entry[data-label]:target::before {
+    font-weight: bold;
+  }
+  .day {
+    visibility: hidden;
+    position: absolute;
+  }
+}


### PR DESCRIPTION
I think this is both a lot easier to write/maintain for us, and a lot nicer to read for the cohort.

There's a `_data/defaultSchedule.yml` with the repeated stuff (check-in, lunch, presentations) etc, and then a `schedule.md` in each week's folder. They get merged together using the start time as the uniqueness ID, preferring the week schedule. So if the week schedule has something at 11:00 it overrides whatever might have been in the default at that time.

The data is structured like this:
```yml
schedule:
  monday:
    - start: 10:00
      end: 10:30
      name: Intro presentation
      type: slides
      url: "/intro-pres"
    - start: 10:30
      end: 11:30
      name: Build a testing library
      type: workshop
      url: "/testing-lib"
```

## Normal view

<img width="1792" alt="Screenshot 2021-03-05 at 17 04 40" src="https://user-images.githubusercontent.com/9408641/110148661-00365980-7dd5-11eb-956e-948219484393.png">

## Linking directly to #wednesday

<img width="1792" alt="Screenshot 2021-03-05 at 17 04 12" src="https://user-images.githubusercontent.com/9408641/110148698-0c221b80-7dd5-11eb-84c7-84581fd9c7a7.png">
