### PR TITLE
Week 1 schedule

### DIFF
--- a/src/_data/defaultSchedule.yml
+++ b/src/_data/defaultSchedule.yml
@@ -15,6 +15,7 @@ monday:
   - start: 17:15
     end: 17:45
     name: Spike preparation
+    url: /handbook/spikes/#what-makes-a-good-research-presentation
   - start: 17:45
     end: 18:00
     name: Check-out
@@ -25,6 +26,7 @@ tuesday:
   - start: 10:00
     end: 10:15
     name: Spike prep
+    url: /handbook/spikes/#what-makes-a-good-research-presentation
   - start: 10:15
     end: 11:00
     name: Spike presentations

--- a/src/_includes/schedule.11ty.js
+++ b/src/_includes/schedule.11ty.js
@@ -20,10 +20,12 @@ exports.render = ({ defaultSchedule, schedule }) => {
           const { start: defaultStart, end: defaultEnd } = defaultEntry;
           const startedDuring = start >= defaultStart && start < defaultEnd;
           const endedDuring = entry.end > defaultStart && end < defaultEnd;
+          const totalEclipse = start <= defaultStart && end >= defaultEnd;
           // override default entry if the new one overlaps it
           // e.g. a week-entry at 13:30 would stop lunch (13:00-14:00) appearing
-          return startedDuring || endedDuring;
+          return startedDuring || endedDuring || totalEclipse;
         });
+
         return !override;
       });
       const mergedDay = [...defaultLeftovers, ...day];

--- a/src/course/syllabus/teamwork/schedule.md
+++ b/src/course/syllabus/teamwork/schedule.md
@@ -1,111 +1,95 @@
-## Day 1
-
-| Time  | Activity                                                                                                    | Learning outcomes                        |
-| ----- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
-| 09:45 | Arrive and meet everyone                                                                                    |                                          |
-| 10:00 | [Welcome talk][welcome-talk-30]                                                                             | A brief history of FAC                   |
-| 10:30 | [Name game][name-game-30]                                                                                   | Meet and learn about FAC 20              |
-| 11:00 | Go through [course schedule][course-schedule-10], [code of conduct][coc-10] & [house rules][house-rules-10] | Understand the community you are joining |
-| 11:30 | [Allyship talk][ally-talk-30]                                                                               | Privilege and allyship                   |
-| 12:00 | [Cohort expectations, by FAC20][student-expectations-45]                                                    |                                          |
-| 12:45 | Introduce Slack channels                                                                                    |                                          |
-| 13:00 | _Lunch_                                                                                                     |                                          |
-| 14:00 | [Intro to pair programming][intro-pairing-60]                                                               | Approaches to pair programming           |
-| 15:00 | [Accessibility workshop][a11y-workshop-60]                                                                  | Building websites for everyone           |
-| 16:00 | [Project intro][project-intro-10]                                                                           | This week's project goals                |
-| 16:10 | [Tech spikes - intro][spikes-intro-5]                                                                       | What is a tech spike?                    |
-| 16:15 | [Tech spikes - research][tech-spikes-60]                                                                    |                                          |
-| 17:15 | [Tech spikes - presentation prep][spikes-presentations-30]                                                  |                                          |
-| 17:45 | Check-out                                                                                                   |                                          |
-
-[welcome-talk-30]: http://facresources.com/slides/students-day-1-talk#/
-[name-game-30]: https://github.com/foundersandcoders/master-reference/blob/master/coursebook/week-1/resources/name-game.md
-[course-schedule-10]: https://founders-and-coders.gitbook.io/coursebook/
-[coc-10]: https://founders-and-coders.gitbook.io/coursebook/student-handbook/code-of-conduct
-[house-rules-10]: https://founders-and-coders.gitbook.io/coursebook/student-handbook/course-rules
-[ally-talk-30]: https://hackmd.io/@fac/HyJimsFc8
-[student-expectations-45]: https://github.com/foundersandcoders/master-reference/blob/master/coursebook/week-1/cohort-code-of-conduct.md
-[intro-pairing-60]: https://founders-and-coders.gitbook.io/coursebook/student-handbook/pair-programming
-[a11y-workshop-60]: /workshops/learn-a11y/
-[project-intro-10]: https://founders-and-coders.gitbook.io/coursebook/curriculum/teamwork-and-toolkit/project
-[spikes-intro-5]: https://founders-and-coders.gitbook.io/coursebook/student-handbook/spikes
-[tech-spikes-60]: https://founders-and-coders.gitbook.io/coursebook/curriculum/teamwork-and-toolkit/spikes
-[spikes-presentations-30]: https://founders-and-coders.gitbook.io/coursebook/student-handbook/spikes#what-makes-a-good-research-presentation
-
-## Day 2
-
-| Time    | Activity                             | Learning outcomes                  |
-| ------- | ------------------------------------ | ---------------------------------- |
-| 09:45   | Hello from pastoral mentor           |                                    |
-| 09:50   | Check-in                             |                                    |
-| 10:00   | Spike prep                           |                                    |
-| 10:10   | [Spike presentations][spike-pres-50] | Presenting and learning CSS & a11y |
-| 11:00   | Anni's talk                          |                                    |
-| 12:30   | [User Manuals][user-manuals-30]      | Reflection and self-discovery      |
-| _13:00_ | _Lunch_                              |                                    |
-| 14:00   | [Design Burst: colour][db-colour-30] | Colour in effective design         |
-| 14:30   | [Colour workshop][db-colour-ws-60]   |                                    |
-| 15:30   | [Git workshop][git-ws-120]           |                                    |
-| 17.30   | Pastoral care                        | Pastoral care on FAC20             |
-| 17:45   | Check-out                            |                                    |
-
-[spikes-presentations-30]: https://founders-and-coders.gitbook.io/coursebook/student-handbook/spikes#what-makes-a-good-research-presentation
-[spike-pres-50]: https://founders-and-coders.gitbook.io/coursebook/student-handbook/spikes#what-makes-a-good-research-presentation
-[user-manuals-30]: https://github.com/fac20/user-manuals
-[db-colour-30]: http://facresources.com/slides/design-burst-week1.html
-[db-colour-ws-60]: https://github.com/bobbysebolao/learn-css-variables
-[git-ws-120]: https://github.com/foundersandcoders/git-workflow-workshop-for-two
-
-## Day 3
-
-| Time    | Activity                                    | Learning outcomes      |
-| ------- | ------------------------------------------- | ---------------------- |
-| 09:45   | Hello from pastoral mentor                  |                        |
-| 09:50   | Check-in                                    |                        |
-| 10:00   | [Learn HTML forms][learn-forms-60]          | HTML forms             |
-| 11:00   | [Intro to project management][pm-slides-15] | Managing tech projects |
-| 11:15   | [Begin projects][projects]                  |                        |
-| _13:00_ | _Lunch_                                     |                        |
-| 14:00   | [Projects][projects]                        |                        |
-| 17:45   | Check-out                                   |                        |
-
-[learn-forms-60]: https://github.com/oliverjam/learn-html-forms/
-[pm-slides-15]: https://hackmd.io/@fac/S1wGfV2M8#/
-[projects]: https://founders-and-coders.gitbook.io/coursebook/curriculum/teamwork-and-toolkit/project
-
-## Day 4
-
-| Time    | Activity                   | Learning outcomes |
-| ------- | -------------------------- | ----------------- |
-| 09:45   | Hello from pastoral mentor |                   |
-| 09:50   | Check-in                   |                   |
-| 10:00   | [Projects][project-info]   |                   |
-| _13:00_ | _Lunch_                    |                   |
-| 14:00   | [Projects][project-info]   |                   |
-| 17:45   | Check-out                  |                   |
-
-[project-info]: https://founders-and-coders.gitbook.io/coursebook/curriculum/teamwork-and-toolkit/project
-
-## Day 5
-
-| Time  | Activity                                                | Learning outcomes                    |
-| ----- | ------------------------------------------------------- | ------------------------------------ |
-| 09:45 | Hello from pastoral mentor                              |                                      |
-| 09:50 | Check-in                                                |                                      |
-| 10:00 | [Team code review][intro-code-review-60]                | Peer reviewing code                  |
-| 10:45 | Live code review                                        | Mentor reviewing code                |
-| 11:15 | Respond to issues                                       |                                      |
-| 12:00 | Sign up for pastoral 'walks'                            |                                      |
-| 12:10 | [Intro to project presentations][intro-project-pres-10] | Guidance on engaging talks           |
-| 12:20 | Presentation prep                                       |                                      |
-| 13:00 | _Lunch_                                                 |                                      |
-| 14:00 | Presentations                                           |                                      |
-| 15:30 | [Intro to Stop Go Continues (SGCs)][intro-retros-15]    | Reflection and retrospection at FAC  |
-| 15:45 | Cohort SGC                                              | How we can be better with each other |
-| 16:15 | Team SGC                                                | How we want to work with each other  |
-| 17:00 | Roundtable                                              |                                      |
-| 17:45 | Check-out                                               |                                      |
-
-[intro-code-review-60]: https://founders-and-coders.gitbook.io/coursebook/student-handbook/code-review
-[intro-project-pres-10]: https://founders-and-coders.gitbook.io/coursebook/student-handbook/projects#project-presentation
-[intro-retros-15]: https://founders-and-coders.gitbook.io/coursebook/student-handbook/retrospectives
+---
+layout: schedule
+schedule:
+  monday:
+    - name: Welcome talk
+      url: http://facresources.com/slides/students-day-1-talk#/
+      start: 10:00
+      end: 10:30
+    - name: Course resources
+      start: 10:30
+      end: 10:45
+    - name: Code of Conduct
+      url: /course/code-of-conduct/
+      start: 10:45
+      end: 11:00
+    - name: Allyship
+      url: https://hackmd.io/@fac/SkMwhF0qU
+      start: 11:00
+      end: 11:30
+    - name: Pastoral care
+      start: 11:30
+      end: 12:00
+    - name: Cohort expectations
+      url: https://github.com/foundersandcoders/master-reference/blob/master/coursebook/week-1/cohort-code-of-conduct.md
+      start: 12:00
+      end: 12:45
+    - name: Discord
+      start: 12:45
+      end: 13:00
+    - name: Intro to pair programming
+      url: /course/handbook/pair-programming/
+      start: 14:00
+      end: 15:00
+    - name: Intro to accessibility
+      url: /workshops/learn-a11y/
+      start: 15:00
+      end: 16:00
+    - name: Project & spikes intro
+      url: ../project
+      start: 16:00
+      end: 16:15
+    - name: Tech spikes research
+      url: ../spikes
+      start: 16:15
+      end: 17:15
+    - name: Tech spikes presentation prep
+      start: 17:15
+      end: 17:45
+  tuesday:
+    - name: Anni's talk
+      start: 11:00
+      end: 12:30
+    - name: User manuals
+      url: https://github.com/fac21/user-manuals
+      start: 12:30
+      end: 13:00
+    - name: Colour design burst
+      url: http://facresources.com/slides/design-burst-week1.html
+      start: 14:00
+      end: 14:30
+    - name: Colour design workshop
+      url: https://github.com/bobbysebolao/learn-css-variables
+      start: 14:30
+      end: 15:30
+    - name: Git workshop
+      url: https://github.com/foundersandcoders/git-workflow-workshop-for-two
+      start: 15:30
+      end: 17:30
+    - name: Pastoral care
+      start: 17:30
+      end: 17:45
+  wednesday:
+    - name: Learn HTML forms
+      url: https://github.com/oliverjam/learn-html-forms/
+      start: 10:00
+      end: 11:00
+    - name: Project management intro
+      url: https://hackmd.io/@fac/S1wGfV2M8#/
+      start: 11:00
+      end: 11:15
+    - name: Project
+      url: ../project
+      start: 11:15
+      end: 13:00
+      type: project
+  thursday:
+  friday:
+    - name: Respond to issues
+      start: 11:15
+      end: 12:00
+    - name: Project presentations intro
+      url: http://localhost:8080/course/handbook/projects/#project-presentation
+      start: 12:00
+      end: 12:15
+---


### PR DESCRIPTION
- Add new Week 1 schedule
- Fix default schedule overriding logic. It now correctly removes whatever was in the default schedule slot if a week schedule has an entry that overlaps at all. E.g. if you schedule something for 13:30 it'll remove lunch for that day. The downside is you have to manually re-include default stuff if you are tweaking times a bit (e.g. "Respond To Issues on Friday here).

<img width="1792" alt="Screenshot 2021-03-06 at 20 35 55" src="https://user-images.githubusercontent.com/9408641/110220122-90e76500-7ebb-11eb-9816-37d47d9fdacb.png">
