### PR TITLE
Update employment mentors to interview prep

### DIFF
--- a/src/course/syllabus/server-side-app/schedule.md
+++ b/src/course/syllabus/server-side-app/schedule.md
@@ -29,8 +29,8 @@ schedule:
       start: 14:00
       end: 16:30
       type: project
-    - name: Employment - Employment mentors
+    - name: Interview Prep - Code Writing
       start: 16:30
       end: 17:45
-      url: https://hackmd.io/@fac/Hy1OHLfXv#/
+      url: https://www.notion.so/foundersandcoders/Code-Writing-5f37dabeebc149309d8b8198304288b9/
 ---


### PR DESCRIPTION
Just to make sure that we're being clear about what is happening this afternoon! Changing the link from an employment mentor talk to the link for code writing exercises