### PR TITLE
Next.js link returning 404

### DIFF
--- a/src/course/syllabus/full-stack-app/schedule.md
+++ b/src/course/syllabus/full-stack-app/schedule.md
@@ -13,7 +13,7 @@ schedule:
     - name: Learn Next.js
       start: 14:00
       end: 17:45
-      url: https://nextjs.org/learn/basics/
+      url: https://nextjs.org/learn/
       type: workshop
   tuesday:
     - name: Project setup


### PR DESCRIPTION
https://learn.foundersandcoders.com/course/syllabus/full-stack-app/schedule/

https://nextjs.org/learn/basics/ -> https://nextjs.org/learn/