### PR TITLE
Fix links that reference source files

### DIFF
--- a/src/course/handbook/learning-circles.md
+++ b/src/course/handbook/learning-circles.md
@@ -1,6 +1,7 @@
 # Learning circles
 
 ## Set up
+
 - Groups of 4. Typically, lasting 90 minutes, with four 20-minute rounds;
 - Start with a check-in and end with a check-out;
 - Inexperienced groups should have a facilitator present.
@@ -18,6 +19,7 @@
 - When the round comes to an end, the next group member takes on the role of presenter and the process is repeated until each member of the group has presented.
 
 Aims:
+
 1. To give each participant an opportunity to get the support of the group with a problem that they are working on;
 2. To give each participant practice in developing questioning strategies to aid problem solving;
 3. To give each participant practice at communicating proposed solutions;
@@ -27,6 +29,5 @@ Aims:
 
 ## Tools
 
-- [Question crib sheet](problem-solving-questions.md), that each respondent can use as a scaffold for their questioning;
-- [Glossary](glossary.md) of terms.
-
+- [Question crib sheet](../problem-solving-questions/), that each respondent can use as a scaffold for their questioning;
+- [Glossary](../glossary/) of terms.

--- a/src/course/syllabus/pre-app-7/schedule.md
+++ b/src/course/syllabus/pre-app-7/schedule.md
@@ -16,4 +16,4 @@ Learn about promises in [this workshop](https://learn.foundersandcoders.com/work
 
 _45 minutes_
 
-Work on getting your [project](project.md) repository set up ready for making API calls next week.
+Work on getting your [project](../project/) repository set up ready for making API calls next week.

--- a/src/course/syllabus/pre-app-8/schedule.md
+++ b/src/course/syllabus/pre-app-8/schedule.md
@@ -10,7 +10,7 @@ Practise what you learnt in the workshop with this [real-world fetch workshop](h
 
 _90 minutes_
 
-Complete the three [Tech Spikes](spikes.md) on debugging JavaScript, asynchronous JavaScript, and debugging network requests.
+Complete the three [Tech Spikes](../spikes) on debugging JavaScript, asynchronous JavaScript, and debugging network requests.
 
 ## Project
 


### PR DESCRIPTION
Links need to point to final built HTML pages rather than `.md` content files. The easiest way is to use relative URLs to reference sibling pages (e.g. `thing.md` -> `../thing/`)