### PR TITLE
Fac22 schedules

### DIFF
--- a/src/_data/defaultSchedule.yml
+++ b/src/_data/defaultSchedule.yml
@@ -39,12 +39,16 @@ tuesday:
   - start: 13:00
     end: 14:00
     name: Lunch
-  - start: 16:00
-    end: 17:00
-    name: Interview practice
-  - start: 17:00
+  - name: Project intro
+    start: 17:00
+    end: 17:15
+    type: project
+    url: ../project
+  - name: Project set up, estimation and testing
+    start: 17:15
     end: 17:45
-    name: Speaker
+    type: project
+    url: ../project
   - start: 17:45
     end: 18:00
     name: Check-out
@@ -52,7 +56,11 @@ wednesday:
   - start: 9:45
     end: 10:00
     name: Check-in
-  - start: 11:00
+  - start: 10:00
+    end: 10:45
+    name: Web Science talk
+    type: presentation
+  - start: 11:45
     end: 13:00
     name: Project
     type: project

--- a/src/course/syllabus/database/schedule.md
+++ b/src/course/syllabus/database/schedule.md
@@ -22,24 +22,27 @@ schedule:
       end: 13:00
       url: /workshops/database-testing
       type: workshop
-    - name: Error-handling
+    - name: Tech for Better - Product pitches
       start: 14:00
-      end: 16:00
+      end: 15:00
+    - name: Error-handling
+      start: 15:00
+      end: 17:00
       url: /workshops/node-error-handling
       type: workshop
   wednesday:
     - name: Heroku SQL challenge
-      start: 10:00
-      end: 11:00
+      start: 10:45
+      end: 11:45
       url: /workshops/heroku-sql-challenge
       type: challenge
     - name: Ceremonies & pair programming
-      start: 11:00
-      end: 11:15
+      start: 11:45
+      end: 12:00
       url: https://hackmd.io/@fac/ryDzAOabv
       type: talk
     - name: Project
-      start: 11:00
+      start: 12:00
       end: 12:45
       type: project
     - name: Role circles

--- a/src/course/syllabus/server/schedule.md
+++ b/src/course/syllabus/server/schedule.md
@@ -41,10 +41,12 @@ schedule:
     - name: Project intro
       start: 17:00
       end: 17:15
-    - name: Project set up
+      url: ../project
+    - name: Project set up, estimation and testing
       start: 17:15
       end: 17:45
       type: project
+      url: ../project
   wednesday:
     - name: Web science talk
       start: 10:00

--- a/src/course/syllabus/server/schedule.md
+++ b/src/course/syllabus/server/schedule.md
@@ -38,27 +38,10 @@ schedule:
       end: 17:00
       url: /workshops/cypress-testing/
       type: workshop
-    - name: Project intro
-      start: 17:00
-      end: 17:15
-      url: ../project
-    - name: Project set up, estimation and testing
-      start: 17:15
-      end: 17:45
-      type: project
-      url: ../project
   wednesday:
-    - name: Web science talk
-      start: 10:00
-      end: 10:45
-      type: presentation
     - name: Node scripting challenge
       start: 10:45
       end: 11:45
       url: /workshops/node-scripting-challenge/
       type: challenge
-    - name: Project
-      start: 11:45
-      end: 13:00
-      type: project
 ---

--- a/src/course/syllabus/server/schedule.md
+++ b/src/course/syllabus/server/schedule.md
@@ -22,31 +22,41 @@ schedule:
       url: /workshops/node-express-server/
       type: workshop
   tuesday:
-    - name: Anni's talk
-      start: 11:00
-      end: 12:30
     - name: Server-side forms
-      start: 12:30
+      start: 11:00
       end: 13:00
       url: /workshops/server-side-forms/
       type: workshop
-    - name: Server-side forms
+    - name: Tech for Better - Introduction
       start: 14:00
-      end: 15:30
-      url: /workshops/server-side-forms/
-      type: workshop
+      end: 14:45
     - name: Mentoring chat
-      start: 15:30
-      end: 15:45
+      start: 14:45
+      end: 15:00
     - name: Testing with Cypress
-      start: 15:45
-      end: 17:45
+      start: 15:00
+      end: 17:00
       url: /workshops/cypress-testing/
       type: workshop
+    - name: Project intro
+      start: 17:00
+      end: 17:15
+    - name: Project set up
+      start: 17:15
+      end: 17:45
+      type: project
   wednesday:
-    - name: Node scripting challenge
+    - name: Web science talk
       start: 10:00
-      end: 11:00
+      end: 10:45
+      type: presentation
+    - name: Node scripting challenge
+      start: 10:45
+      end: 11:45
       url: /workshops/node-scripting-challenge/
       type: challenge
+    - name: Project
+      start: 11:45
+      end: 13:00
+      type: project
 ---


### PR DESCRIPTION
So this is where I got to with rejigging the schedules for the first few weeks. There's a couple of things to consider:
- Adding the web science curriculum (#475)
- Adding Tech for Better (#473)
- Adding time for testing and estimation (#452)
- Adding some time for inductions in the first week
- There's a bank holiday schedule for Server Side App which won't be a BH for FAC22