### PR TITLE
move role circles to thursday mornings

### DIFF
--- a/src/_data/defaultSchedule.yml
+++ b/src/_data/defaultSchedule.yml
@@ -73,7 +73,11 @@ thursday:
   - start: 9:45
     end: 10:00
     name: Check-in
-  - start: 10:00
+  - name: Role circles
+    start: 10:00
+    end: 10:15
+    url: /course/handbook/role-circles
+  - start: 10:15
     end: 13:00
     name: Project
     type: project

--- a/src/course/syllabus/apprenticeship/authentication/schedule.md
+++ b/src/course/syllabus/apprenticeship/authentication/schedule.md
@@ -45,13 +45,4 @@ schedule:
       start: 11:00
       end: 13:00
       type: project
-  thursday:
-    - name: Role circles
-      start: 10:00
-      end: 10:15
-      url: /course/handbook/role-circles
-    - name: Projects
-      start: 10:15
-      end: 13:00
-      type: project
 ---

--- a/src/course/syllabus/apprenticeship/authentication/schedule.md
+++ b/src/course/syllabus/apprenticeship/authentication/schedule.md
@@ -43,9 +43,15 @@ schedule:
       type: talk
     - name: Project
       start: 11:00
-      end: 12:45
-      type: project
-    - name: Role circles
-      start: 12:45
       end: 13:00
+      type: project
+  thursday:
+    - name: Role circles
+      start: 10:00
+      end: 10:15
+      url: /course/handbook/role-circles
+    - name: Projects
+      start: 10:15
+      end: 13:00
+      type: project
 ---

--- a/src/course/syllabus/apprenticeship/client-side-app/schedule.md
+++ b/src/course/syllabus/apprenticeship/client-side-app/schedule.md
@@ -46,17 +46,8 @@ schedule:
       end: 11:00
       url: /workshops/react-refactor-classes/
       type: challenge
-    - name: Projects
+    - name: Project
       start: 11:00
-      end: 13:00
-      type: project
-  thursday:
-    - name: Role circles
-      start: 10:00
-      end: 10:15
-      url: /course/handbook/role-circles
-    - name: Projects
-      start: 10:15
       end: 13:00
       type: project
 ---

--- a/src/course/syllabus/apprenticeship/client-side-app/schedule.md
+++ b/src/course/syllabus/apprenticeship/client-side-app/schedule.md
@@ -48,10 +48,15 @@ schedule:
       type: challenge
     - name: Projects
       start: 11:00
-      end: 12:45
-      type: project
-    - name: Role circles
-      start: 12:45
       end: 13:00
+      type: project
+  thursday:
+    - name: Role circles
+      start: 10:00
+      end: 10:15
       url: /course/handbook/role-circles
+    - name: Projects
+      start: 10:15
+      end: 13:00
+      type: project
 ---

--- a/src/course/syllabus/apprenticeship/database/schedule.md
+++ b/src/course/syllabus/apprenticeship/database/schedule.md
@@ -47,18 +47,18 @@ schedule:
       type: challenge
     - name: Project
       start: 11:00
-      end: 12:45
-      type: project
-    - name: Role circles
-      start: 12:45
       end: 13:00
-      url: /course/handbook/role-circles
+      type: project
   thursday:
     - name: Digital 101
       start: 10:00
       end: 11:30
-    - name: Project
+    - name: Role circles
       start: 11:30
+      end: 11:45
+      url: /course/handbook/role-circles
+    - name: Project
+      start: 11:45
       end: 13:00
       type: project
   friday:

--- a/src/course/syllabus/apprenticeship/full-stack-app/schedule.md
+++ b/src/course/syllabus/apprenticeship/full-stack-app/schedule.md
@@ -32,14 +32,14 @@ schedule:
       end: 17:45
       type: project
   wednesday:
-    - name: Project
-      start: 10:00
-      end: 12:45
-      type: project
     - name: Role circles
-      start: 12:45
-      end: 13:00
+      start: 10:00
+      end: 10:15
       url: /course/handbook/role-circles
+    - name: Project
+      start: 10:15
+      end: 13:00
+      type: project
   thursday:
     - name: Project
       start: 10:00

--- a/src/course/syllabus/apprenticeship/server-side-app/schedule.md
+++ b/src/course/syllabus/apprenticeship/server-side-app/schedule.md
@@ -16,7 +16,7 @@ schedule:
       end: 17:45
       url: ../spikes
   tuesday:
-    - name: Projects
+    - name: Project
       start: 10:00
       end: 12:45
       type: project
@@ -27,7 +27,7 @@ schedule:
     - name: TFB - Discovery
       start: 14:00
       end: 15:00
-    - name: Projects
+    - name: Project
       start: 15:00
       end: 17:45
       type: project
@@ -36,8 +36,13 @@ schedule:
       start: 10:00
       end: 10:15
       url: /course/handbook/role-circles
-    - name: Projects
+    - name: Project
       start: 10:15
+      end: 13:00
+      type: project
+  thursday:
+    - name: Project
+      start: 10:00
       end: 13:00
       type: project
 ---

--- a/src/course/syllabus/apprenticeship/server-side-app/schedule.md
+++ b/src/course/syllabus/apprenticeship/server-side-app/schedule.md
@@ -32,12 +32,12 @@ schedule:
       end: 17:45
       type: project
   wednesday:
-    - name: Projects
-      start: 10:00
-      end: 12:45
-      type: project
     - name: Role circles
-      start: 12:45
-      end: 13:00
+      start: 10:00
+      end: 10:15
       url: /course/handbook/role-circles
+    - name: Projects
+      start: 10:15
+      end: 13:00
+      type: project
 ---


### PR DESCRIPTION
The cohort have said that they much prefer role circles to be part of the standup on the second day, once they've had a chance to work on their projects a little.

Database week is a weird one because of the web science talk, and for the two weeks  with three day projects I've kept it on wednesday as that is day 2. (next and server side week)