### PR TITLE
Add flag to use npm instead of yarn

### DIFF
--- a/src/course/syllabus/apprenticeship/full-stack-app/project.md
+++ b/src/course/syllabus/apprenticeship/full-stack-app/project.md
@@ -37,7 +37,7 @@ It's important to get your project setup done as early as possible, so your team
 Generate a Next app with:
 
 ```shell
-npx create-next-app
+npx create-next-app --use-npm
 ```
 
 {% box %}


### PR DESCRIPTION
Yarn is the default installer for create-next-app

FAC24 ran into a yarn.lock file after creating their next project - was confusing as they hadn't encountered yarn before.

I've updated this to pass in a flag to explicitly install extra dependencies for create-next-app with npm instead of yarn.