### PR TITLE
Increase min Node version to 18

### DIFF
--- a/src/course/handbook/installation.md
+++ b/src/course/handbook/installation.md
@@ -84,13 +84,17 @@ curl https://get.volta.sh | bash
 
 You may have to restart your Terminal afterwards.
 
-You can now use Volta to install different versions of Node:
+You can now use Volta to install different versions of Node. We require Node version 18 for our programme, so you need to specify that:
 
 ```bash
-volta install node
+volta install node@18
 ```
 
-This will automatically pick the current "Long-Term Support" (LTS) version of Node, which is usually what you want.
+Volta should install Node 18 and automatically start using it. You can check it worked by running this command:
+
+```shell
+node --version
+```
 
 #### npm
 


### PR DESCRIPTION
We want to rely on a couple of new features in Node 18 (built-in testing and `fetch`).

Node 18 will be the new LTS as of October, so we can change this back to just `volta install node` for the next cohort