### PR TITLE
update monday/tuesday to remove Employer Day, allowing for review of …

### DIFF
--- a/src/_data/defaultSchedule.yml
+++ b/src/_data/defaultSchedule.yml
@@ -35,7 +35,7 @@ tuesday:
   - name: Project spike
     start: 16:15
     end: 17:45
-    url: ../project#spike
+    url: ../project#spikes
   - start: 17:45
     end: 18:00
     name: Check-out

--- a/src/course/syllabus/apprenticeship/server-side-app/schedule.md
+++ b/src/course/syllabus/apprenticeship/server-side-app/schedule.md
@@ -2,19 +2,19 @@
 layout: schedule
 schedule:
   monday:
-  tuesday:
-    - name: Client-side validation
-      start: 10:00
-      end: 12:15
-      url: /workshops/form-validation/
+    - name: Validation workshop
+      url: /workshops/form-validation
       type: workshop
+      start: 9:45
+      end: 18:00
+  tuesday:
     - name: Project and spike intro
-      start: 12:15
-      end: 12:30
+      start: 12:00
+      end: 12:15
       type: project
       url: ../project
     - name: Project spike
-      start: 12:30
+      start: 12:15
       end: 13:00
       url: ../project#spike
     - name: Draft a project idea

--- a/src/course/syllabus/apprenticeship/server-side-app/schedule.md
+++ b/src/course/syllabus/apprenticeship/server-side-app/schedule.md
@@ -2,13 +2,28 @@
 layout: schedule
 schedule:
   monday:
-    - name: Employer day
-      start: 9:45
-      end: 18:00
   tuesday:
+    - name: Client-side validation
+      start: 10:00
+      end: 12:15
+      url: /workshops/form-validation/
+      type: workshop
+    - name: Project and spike intro
+      start: 12:15
+      end: 12:30
+      type: project
+      url: ../project
+    - name: Project spike
+      start: 12:30
+      end: 13:00
+      url: ../project#spike
     - name: Draft a project idea
       start: 15:45
       end: 16:00
+    - name: Project spike
+      start: 16:00
+      end: 17:45
+      url: ../project#spike
   wednesday:
   thursday:
   friday:

--- a/src/course/syllabus/apprenticeship/server-side-app/schedule.md
+++ b/src/course/syllabus/apprenticeship/server-side-app/schedule.md
@@ -6,6 +6,10 @@ schedule:
       url: /workshops/form-validation
       type: workshop
       start: 9:45
+      end: 12:00
+    - name: Workshop revision
+      type: workshop
+      start: 12:00
       end: 18:00
   tuesday:
     - name: Project and spike intro
@@ -16,14 +20,14 @@ schedule:
     - name: Project spike
       start: 12:15
       end: 13:00
-      url: ../project#spike
+      url: ../project#spikes
     - name: Draft a project idea
       start: 15:45
       end: 16:00
     - name: Project spike
       start: 16:00
       end: 17:45
-      url: ../project#spike
+      url: ../project#spikes
   wednesday:
   thursday:
   friday:


### PR DESCRIPTION
…previous workshops on monday; add client-side validation to tuesday; add additional Spike time tues. TO-DO: Update url for client-side validation reconfigured as it's own repo.