### PR TITLE
bring 'Code Review' + 'Sprint Review and Planning' forward to Thurs p…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "coursebook",
       "version": "1.0.0",
       "hasInstallScript": true,
       "license": "MIT",

--- a/src/course/syllabus/projects/TFB-build-1/schedule.md
+++ b/src/course/syllabus/projects/TFB-build-1/schedule.md
@@ -59,15 +59,23 @@ schedule:
       type: project
     - name: Build
       start: 14:00
-      end: 17:45
+      end: 15:45
       type: project
-  friday:
     - name: Team code review
-      start: 10:00
-      end: 11:00
+      start: 15:45
+      end: 16:45
       url: /course/handbook/code-review/
-    - name: Sprint Review
-      start: 11:00
-      end: 12:00
+    - name: Sprint Review and Planning
+      start: 16:45
+      end: 17:45
       url: /course/handbook/project-docs/sprint-planning
+  friday:
+    - name: Respond to issues
+      start: 10:00
+      end: 12:00
+      type: project
+    - name: Project documentation
+      start: 16:20
+      end: 16:50
+      url: /course/handbook/project-documentation/
 ---

--- a/src/course/syllabus/projects/TFB-design/schedule.md
+++ b/src/course/syllabus/projects/TFB-design/schedule.md
@@ -81,4 +81,8 @@ schedule:
       start: 10:00
       end: 12:00
       type: project
+    - name: Project documentation
+      start: 16:20
+      end: 16:50
+      url: /course/handbook/project-documentation/
 ---

--- a/src/course/syllabus/projects/in-house-build-1/schedule.md
+++ b/src/course/syllabus/projects/in-house-build-1/schedule.md
@@ -57,15 +57,23 @@ schedule:
       type: project
     - name: Build
       start: 14:00
-      end: 17:45
+      end: 15:45
       type: project
-  friday:
     - name: Team code review
-      start: 10:00
-      end: 11:00
+      start: 15:45
+      end: 16:45
       url: /course/handbook/code-review/
     - name: Sprint Review and Planning
-      start: 11:00
-      end: 12:00
+      start: 16:45
+      end: 17:45
       url: /course/handbook/project-docs/sprint-planning
+  friday:
+    - name: Respond to issues
+      start: 10:00
+      end: 12:00
+      type: project
+    - name: Project documentation
+      start: 16:20
+      end: 16:50
+      url: /course/handbook/project-documentation/
 ---

--- a/src/course/syllabus/projects/in-house-build-2/schedule.md
+++ b/src/course/syllabus/projects/in-house-build-2/schedule.md
@@ -58,15 +58,23 @@ schedule:
       type: project
     - name: Build
       start: 14:00
-      end: 17:45
+      end: 15:45
       type: project
-  friday:
     - name: Team code review
-      start: 10:00
-      end: 11:00
+      start: 15:45
+      end: 16:45
       url: /course/handbook/code-review/
-    - name: Sprint Review
-      start: 11:00
-      end: 12:00
+    - name: Sprint Review and Planning
+      start: 16:45
+      end: 17:45
       url: /course/handbook/project-docs/sprint-planning
+  friday:
+    - name: Respond to issues
+      start: 10:00
+      end: 12:00
+      type: project
+    - name: Project documentation
+      start: 16:20
+      end: 16:50
+      url: /course/handbook/project-documentation/
 ---

--- a/src/course/syllabus/projects/in-house-design/schedule.md
+++ b/src/course/syllabus/projects/in-house-design/schedule.md
@@ -112,4 +112,8 @@ schedule:
       start: 10:15
       end: 12:00
       url: /course/handbook/project-docs/sprint-planning
+    - name: Project documentation
+      start: 16:20
+      end: 16:50
+      url: /course/handbook/project-documentation/
 ---


### PR DESCRIPTION
…m; make 10-12 on Fri's 'Respond to Issues/Build' (brought forward from Mon); remove 'Intro to next week', add 'Project Documentation' instead.