### PR TITLE
Clarify Next project could use cookies instead of localstorage

### DIFF
--- a/src/course/syllabus/developer/full-stack-app/project.md
+++ b/src/course/syllabus/developer/full-stack-app/project.md
@@ -19,7 +19,7 @@ Remember that Next doesn't work that differently to the Express apps you've buil
 
 - "Add to basket" button on product pages
 - Basket page showing all saved items
-- Basket contents persisted for future visits (local storage)
+- Basket contents persisted for future visits (cookies or local storage)
 - Filter products by category
 - Sort products by price
 - End-to-end tests


### PR DESCRIPTION
When I wrote this project I intended learners to keep using the knowledge from the prior weeks, so storing info server-side using cookies + DB. I imagine a lot of learners have found it easier to use localStorage though since Next doesn't exactly make it obvious how to do cookie stuff.