### PR TITLE
Expert feedback slots

### DIFF
--- a/src/_data/defaultSchedule.yml
+++ b/src/_data/defaultSchedule.yml
@@ -141,6 +141,7 @@ friday:
   - name: Progress Log
     start: 10:00
     end: 10:30
+    type: expert-feedback
   - name: Workshop
     start: 10:30
     end: 18:00

--- a/src/_data/defaultSchedule.yml
+++ b/src/_data/defaultSchedule.yml
@@ -96,8 +96,9 @@ thursday:
     name: Check-in
   - start: 10:00
     end: 11:00
-    name: Live code review
+    name: Expert Feedback - Live code review
     url: /course/handbook/code-review/
+    type: expert-feedback
   - start: 11:00
     end: 12:00
     name: Respond to issues

--- a/src/course/syllabus/developer/app/schedule.md
+++ b/src/course/syllabus/developer/app/schedule.md
@@ -70,7 +70,7 @@
 | ----- | ------------------- |
 | 09:45 | Check-in            |
 | 10:00 | Team code review    |
-| 10:45 | Live code review    |
+| 10:45 | Expert Feedback - Live code review    |
 | 11:15 | Respond to issues   |
 | 12:00 | Role circles        |
 | 12:15 | Presentation prep   |

--- a/src/course/syllabus/developer/authentication/schedule.md
+++ b/src/course/syllabus/developer/authentication/schedule.md
@@ -96,10 +96,6 @@ schedule:
     - name: Check-in
       start: 9:45
       end: 10:00
-    - start: 10:00
-      end: 11:00
-      name: Live code review
-      url: /course/handbook/code-review/
     - start: 11:00
       end: 12:00
       name: Respond to issues

--- a/src/course/syllabus/developer/authentication/schedule.md
+++ b/src/course/syllabus/developer/authentication/schedule.md
@@ -133,10 +133,11 @@ schedule:
       end: 18:00
       name: Check-out
   friday:
-    - start: 10:30
+    - name: Progress Log Review
+      start: 10:00
       end: 11:30
-      name: Progress Log Review
-    - start: 11:30
+      type: expert-feedback
+    - name: Consolidation
+      start: 11:30
       end: 18:00
-      name: Consolidation
 ---

--- a/src/course/syllabus/developer/full-stack-app/schedule.md
+++ b/src/course/syllabus/developer/full-stack-app/schedule.md
@@ -29,9 +29,10 @@ schedule:
       end: 16:00
       url: https://fac-slides.netlify.app/slides/design-sprint/
   friday:
-    - start: 10:30
+    - name: Progress Log Review
+      start: 10:00
       end: 11:30
-      name: Progress Log Review
+      type: expert-feedback
     - name: Consolidation day
       start: 11:30
       end: 18:00

--- a/src/course/syllabus/developer/projects/in-house-build-2/schedule.md
+++ b/src/course/syllabus/developer/projects/in-house-build-2/schedule.md
@@ -68,12 +68,10 @@ schedule:
       end: 16:00
       url: /course/handbook/project-documentation/
   friday:
-    - name: Progress Log
-      start: 9:45
-      end: 10:30
-    - start: 10:30
+    - name: Progress Log Review
+      start: 10:00
       end: 11:30
-      name: Progress Log Review
+      type: expert-feedback
     - name: Consolidation day
       start: 11:30
       end: 18:00

--- a/src/course/syllabus/tfb/week 10/content.md
+++ b/src/course/syllabus/tfb/week 10/content.md
@@ -21,7 +21,7 @@
 
 ### Thursday
 
-- Live code review
+- Expert Feedback - Live code review
 - Sprint planning
 - Presentation prep
 - Team SGC

--- a/src/styles/partials/timetable.css
+++ b/src/styles/partials/timetable.css
@@ -78,6 +78,11 @@
   --sat: 60%;
 }
 
+.entry.expert-feedback {
+  --hue: 100;
+  --sat: 60%;
+}
+
 .entry dt {
   font-size: 0.75rem;
 }


### PR DESCRIPTION
Closes #935 

Edited the default schedule so that all 'Live Code Review' slots are now prefaced with 'Expert Feedback' and are highlighted in the same colour as 'Thought of the Week' slots to correlate any sessions where material or feedback is delivered by the FAC team to the learners.

![Expert Feedback - Live Code Review slot](https://github.com/foundersandcoders/coursebook/assets/114600712/1e71695f-fd42-4904-b3fd-f7df390fd761)

Edited all Progress Log and Progress Log Review sessions to be displayed in the same colour as Live Code Review and Thought of the Week

![Progress Log slot](https://github.com/foundersandcoders/coursebook/assets/114600712/d714c4ba-1cb7-4dfe-a875-a681421e4b74)

Week 10 Thought of the Week session now displayed as 'Presentation Feedback' and again displayed in the same colour as all other content delivery sessions

![Presentation Feedback slot](https://github.com/foundersandcoders/coursebook/assets/114600712/9e93e79f-42b4-4b05-ae75-6c469e255c05)
