### PR TITLE
add starter files to node-npm-intro workshop

### DIFF
--- a/src/workshops/node-npm-intro/starter-files/asciiArtGenerator.js
+++ b/src/workshops/node-npm-intro/starter-files/asciiArtGenerator.js
@@ -1,0 +1,27 @@
+const figlet = require('figlet');
+const fs = require('fs');
+
+function createAsciiArt(text) {
+    return new Promise((resolve, reject) => {
+        figlet(text, (err, data) => {
+            if (err) {
+                reject('Something went wrong...');
+            } else {
+                resolve(data);
+            }
+        });
+    });
+}
+
+async function main() {
+    try {
+        const text = "Hello World"; // You can change this text
+        const asciiArt = await createAsciiArt(text);
+        fs.writeFileSync('asciiArt.txt', asciiArt);
+        console.log('ASCII Art has been written to asciiArt.txt');
+    } catch (error) {
+        console.error(error);
+    }
+}
+
+main();

--- a/src/workshops/node-npm-intro/starter-files/package.json
+++ b/src/workshops/node-npm-intro/starter-files/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "worksop",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "figlet": "^1.7.0"
+  }
+}


### PR DESCRIPTION
Strangely the node-npm-intro workshop has no starter files so I have added some here. More updates to come for this particular workshop but I want these files in the main repo so I can test the script to download the files is working.