### PR TITLE
replace handbook archive links with notion docs

### DIFF
--- a/src/_data/defaultSchedule.yml
+++ b/src/_data/defaultSchedule.yml
@@ -20,7 +20,6 @@ monday:
   - name: Tech for Better
     start: 14:00
     end: 15:30
-    url: /course/handbook/tech-for-better/
   - name: Break
     start: 15:30
     end: 15:45
@@ -47,7 +46,7 @@ tuesday:
     end: 13:00
     name: Project
     type: project
-    url: /course/handbook/projects/
+    url: ../project
   - start: 13:00
     end: 14:00
     name: Lunch
@@ -55,7 +54,7 @@ tuesday:
     end: 17:45
     name: Project
     type: project
-    url: /course/handbook/projects/
+    url: ../project
   - start: 17:45
     end: 18:00
     name: Check-out
@@ -66,12 +65,12 @@ wednesday:
   - name: Role circles
     start: 10:00
     end: 10:15
-    url: /course/handbook/role-circles
+    url: https://foundersandcoders.notion.site/Role-circles-a2371aab24f34955a69904b87ffc1f05
   - start: 10:15
     end: 13:00
     name: Project
     type: project
-    url: /course/handbook/projects/
+    url: ../project
   - start: 13:00
     end: 14:00
     name: Lunch
@@ -79,14 +78,14 @@ wednesday:
     end: 16:30
     name: Project
     type: project
-    url: /course/handbook/projects/
+    url: ../project
   - start: 16:30
     end: 16:45
     name: Update READMEs
   - start: 16:45
     end: 17:45
     name: Team code review
-    url: /course/handbook/code-review/
+    url: https://foundersandcoders.notion.site/Code-Reviews-5c3b987ed1204e46b4c738da538a758c
   - start: 17:45
     end: 18:00
     name: Check-out
@@ -97,7 +96,7 @@ thursday:
   - start: 10:00
     end: 11:00
     name: Expert Feedback - Live code review
-    url: /course/handbook/code-review/
+    url: https://foundersandcoders.notion.site/Code-Reviews-5c3b987ed1204e46b4c738da538a758c
     type: expert-feedback
   - start: 11:00
     end: 12:00
@@ -106,14 +105,14 @@ thursday:
   - start: 12:00
     end: 13:00
     name: Presentation prep
-    url: /course/handbook/project-presentations/
+    url: https://foundersandcoders.notion.site/Project-presentations-d8787b65e78a4314b62475552e7989e9
   - start: 13:00
     end: 14:00
     name: Lunch
   - start: 14:00
     end: 14:30
     name: Team SGC
-    url: /course/handbook/retrospectives/#team-retrospectives
+    url: https://foundersandcoders.notion.site/Retrospectives-cbfd57e19cd24c61a6bd8db16fe0f347
   - start: 14:30
     end: 15:30
     name: Presentations
@@ -124,7 +123,7 @@ thursday:
   - start: 16:00
     end: 16:50
     name: Cohort SGC
-    url: /course/handbook/retrospectives/#cohort-retrospective
+    url: https://foundersandcoders.notion.site/Retrospectives-cbfd57e19cd24c61a6bd8db16fe0f347
   - start: 16:50
     end: 17:00
     name: Break

--- a/src/course/syllabus/developer/authentication/schedule.md
+++ b/src/course/syllabus/developer/authentication/schedule.md
@@ -18,7 +18,6 @@ schedule:
     - name: Tech for Better
       start: 14:00
       end: 16:30
-      url: /course/handbook/tech-for-better/
     - name: Break
       start: 16:30
       end: 16:45
@@ -47,7 +46,7 @@ schedule:
       end: 13:00
       name: Project
       type: project
-      url: /course/handbook/projects/
+      url: ../project
     - start: 13:00
       end: 14:00
       name: Lunch
@@ -55,7 +54,7 @@ schedule:
       end: 17:45
       name: Project
       type: project
-      url: /course/handbook/projects/
+      url: ../project
     - start: 17:45
       end: 18:00
       name: Check-out
@@ -67,12 +66,12 @@ schedule:
     - name: Role circles
       start: 10:00
       end: 10:15
-      url: /course/handbook/role-circles
+      url: https://foundersandcoders.notion.site/Role-circles-a2371aab24f34955a69904b87ffc1f05
     - start: 10:15
       end: 13:00
       name: Project
       type: project
-      url: /course/handbook/projects/
+      url: ../project
     - start: 13:00
       end: 14:00
       name: Lunch
@@ -80,14 +79,14 @@ schedule:
       end: 16:30
       name: Project
       type: project
-      url: /course/handbook/projects/
+      url: ../project
     - start: 16:30
       end: 16:45
       name: Update READMEs
     - start: 16:45
       end: 17:45
       name: Team code review
-      url: /course/handbook/code-review/
+      url: https://foundersandcoders.notion.site/Code-Reviews-5c3b987ed1204e46b4c738da538a758c
     - start: 17:45
       end: 18:00
       name: Check-out
@@ -103,14 +102,13 @@ schedule:
     - start: 12:00
       end: 13:00
       name: Presentation prep
-      url: /course/handbook/project-presentations/
+      url: https://foundersandcoders.notion.site/Project-presentations-d8787b65e78a4314b62475552e7989e9
     - start: 13:00
       end: 14:00
       name: Lunch
     - start: 14:00
       end: 14:30
       name: Team SGC
-      url: /course/handbook/retrospectives/#team-retrospectives
     - start: 14:30
       end: 15:30
       name: Presentations
@@ -122,7 +120,6 @@ schedule:
     - start: 16:00
       end: 16:50
       name: Cohort SGC
-      url: /course/handbook/retrospectives/#cohort-retrospective
     - start: 16:50
       end: 17:00
       name: Break

--- a/src/course/syllabus/developer/introduction/schedule.md
+++ b/src/course/syllabus/developer/introduction/schedule.md
@@ -29,7 +29,7 @@ schedule:
       end: 16:15
       url: /course/syllabus/developer/introduction/topicIntro/
     - name: Break
-      url: /course/handbook/installation/
+      url: https://foundersandcoders.notion.site/Installation-Guide-879500e472964043a17a1ad886b0905b
       start: 16:15
       end: 16:30
     - name: Thought of the week (safeguarding)
@@ -38,7 +38,7 @@ schedule:
       start: 16:30
       end: 17:15
     - name: Social
-      url: /course/handbook/installation/
+      url: https://foundersandcoders.notion.site/Installation-Guide-879500e472964043a17a1ad886b0905b
       start: 17:15
       end: 18:00
   friday:

--- a/src/course/syllabus/developer/projects/TFB-build-1/schedule.md
+++ b/src/course/syllabus/developer/projects/TFB-build-1/schedule.md
@@ -13,7 +13,6 @@ schedule:
     - name: Mentoring reflections & Mentor Scheduling
       start: 16:30
       end: 17:45
-      url: /course/handbook/project-docs/mentoring
   tuesday:
     - name: Build
       start: 10:00
@@ -22,7 +21,7 @@ schedule:
     - name: Role circles
       start: 12:45
       end: 13:00
-      url: /course/handbook/role-circles
+      url: https://foundersandcoders.notion.site/Role-circles-a2371aab24f34955a69904b87ffc1f05
     - name: Build
       start: 14:00
       end: 17:45
@@ -46,7 +45,7 @@ schedule:
     - name: Team code review
       start: 16:15
       end: 17:45
-      url: /course/handbook/code-review/
+      url: https://foundersandcoders.notion.site/Code-Reviews-5c3b987ed1204e46b4c738da538a758c
   thursday:
     - name: Review issues
       start: 10:00
@@ -56,15 +55,14 @@ schedule:
       start: 11:45
       end: 13:00
       type: project
-      url: /course/handbook/project-docs/sprint-planning
     - name: Presentation prep
       start: 14:00
       end: 14:45
-      url: /course/handbook/project-presentations/
+      url: https://foundersandcoders.notion.site/Project-presentations-d8787b65e78a4314b62475552e7989e9
     - name: Team SGC
       start: 14:45
       end: 15:15
-      url: /course/handbook/retrospectives/#team-retrospectives
+      url: https://foundersandcoders.notion.site/Retrospectives-cbfd57e19cd24c61a6bd8db16fe0f347
     - name: Presentations
       start: 15:15
       end: 16:15
@@ -72,7 +70,6 @@ schedule:
     - name: Project documentation
       start: 16:15
       end: 16:45
-      url: /course/handbook/project-documentation/
     - name: Break
       start: 16:45
       end: 17:00

--- a/src/course/syllabus/developer/projects/TFB-build-1/spikes.md
+++ b/src/course/syllabus/developer/projects/TFB-build-1/spikes.md
@@ -2,6 +2,6 @@
 
 There are no defined spikes for this week.
 
-You may find that you need to manage spikes within your sprints. Remember to follow [the techniques you followed earlier in the programme](/course/handbook/spikes).
+You may find that you need to manage spikes within your sprints. Remember to follow [the techniques you followed earlier in the programme](https://foundersandcoders.notion.site/Tech-Spikes-c906c62afc3747ef9ecfcb45a9ccf984).
 
 You're encouraged to continue role circles with those who are playing the same role as you.

--- a/src/course/syllabus/developer/projects/TFB-build-2/schedule.md
+++ b/src/course/syllabus/developer/projects/TFB-build-2/schedule.md
@@ -22,7 +22,7 @@ schedule:
     - name: Role circles
       start: 12:45
       end: 13:00
-      url: /course/handbook/role-circles
+      url: https://foundersandcoders.notion.site/Role-circles-a2371aab24f34955a69904b87ffc1f05
     - name: Build
       start: 14:00
       end: 17:45
@@ -41,7 +41,6 @@ schedule:
     - name: Presentation prep
       start: 15:30
       end: 17:00
-      url: /course/handbook/project-docs/tfb-presentations
     - name: Presentations (practice run)
       start: 17:00
       end: 17:45
@@ -56,15 +55,12 @@ schedule:
     - name: Handover documentation
       start: 11:30
       end: 13:00
-      url: /course/handbook/project-docs/product-handover
     - name: Presentation prep
       start: 14:00
       end: 15:00
-      url: /course/handbook/project-docs/tfb-presentations
     - name: Product handover
       start: 15:00
       end: 15:45
-      url: /course/handbook/project-docs/product-handover
     - name: Presentation practice
       start: 15:45
       end: 16:45

--- a/src/course/syllabus/developer/projects/TFB-build-2/spikes.md
+++ b/src/course/syllabus/developer/projects/TFB-build-2/spikes.md
@@ -2,6 +2,6 @@
 
 There are no defined spikes for this week.
 
-You may find that you need to manage spikes within your sprints. Remember to follow [the techniques you followed earlier in the programme](/course/handbook/spikes).
+You may find that you need to manage spikes within your sprints. Remember to follow [the techniques you followed earlier in the programme](https://foundersandcoders.notion.site/Tech-Spikes-c906c62afc3747ef9ecfcb45a9ccf984).
 
 You're encouraged to continue role circles with those who are playing the same role as you.

--- a/src/course/syllabus/developer/projects/TFB-design/schedule.md
+++ b/src/course/syllabus/developer/projects/TFB-design/schedule.md
@@ -43,7 +43,7 @@ schedule:
     - name: Choose Roles
       start: 10:00
       end: 10:30
-      url: /course/handbook/project-team
+      url: https://foundersandcoders.notion.site/Project-roles-c2be6c42f4fe4bb0911049b084c51791
       type: project
     - name: Code Planning
       start: 10:30
@@ -68,7 +68,6 @@ schedule:
       start: 11:00
       end: 13:00
       type: project
-      url: /course/handbook/project-docs/sprint-planning
     - name: Build
       start: 14:00
       end: 15:45
@@ -85,15 +84,13 @@ schedule:
       start: 11:00
       end: 13:00
       type: project
-      url: /course/handbook/project-docs/sprint-planning
     - start: 14:00
       end: 14:30
       name: Presentation prep
-      url: /course/handbook/project-presentations/
     - name: Team SGC
       start: 14:30
       end: 15:00
-      url: /course/handbook/retrospectives/#team-retrospectives
+      url: https://foundersandcoders.notion.site/Retrospectives-cbfd57e19cd24c61a6bd8db16fe0f347
     - name: Presentations
       start: 15:00
       end: 16:00
@@ -105,7 +102,6 @@ schedule:
     - name: Project documentation
       start: 9:45
       end: 10:30
-      url: /course/handbook/project-documentation/
     - name: Build
       start: 10:30
       end: 13:00

--- a/src/course/syllabus/developer/projects/in-house-build-1/schedule.md
+++ b/src/course/syllabus/developer/projects/in-house-build-1/schedule.md
@@ -23,7 +23,7 @@ schedule:
     - name: Role circles
       start: 12:45
       end: 13:00
-      url: /course/handbook/role-circles
+      url: https://foundersandcoders.notion.site/Role-circles-a2371aab24f34955a69904b87ffc1f05
     - name: Build
       start: 14:00
       end: 17:45
@@ -47,7 +47,7 @@ schedule:
     - name: Team code review
       start: 16:15
       end: 17:45
-      url: /course/handbook/code-review/
+      url: https://foundersandcoders.notion.site/Code-Reviews-5c3b987ed1204e46b4c738da538a758c
   thursday:
     - name: Review issues
       start: 10:00
@@ -57,19 +57,17 @@ schedule:
       start: 11:45
       end: 13:00
       type: project
-      url: /course/handbook/project-docs/sprint-planning
     - name: Tech For Better prototyping
       start: 14:00
       end: 15:45
     - name: Team SGC
       start: 15:45
       end: 16:15
-      url: /course/handbook/retrospectives/#team-retrospectives
+      url: https://foundersandcoders.notion.site/Retrospectives-cbfd57e19cd24c61a6bd8db16fe0f347
       type: presentation
     - name: Project documentation
       start: 16:15
       end: 16:45
-      url: /course/handbook/project-documentation/
     - name: Break
       start: 16:45
       end: 17:00

--- a/src/course/syllabus/developer/projects/in-house-build-1/spikes.md
+++ b/src/course/syllabus/developer/projects/in-house-build-1/spikes.md
@@ -2,6 +2,6 @@
 
 There are no defined spikes for this week.
 
-You may find that you need to manage spikes within your sprints. Remember to follow [the techniques you followed earlier in the programme](/course/handbook/spikes).
+You may find that you need to manage spikes within your sprints. Remember to follow [the techniques you followed earlier in the programme](https://foundersandcoders.notion.site/Tech-Spikes-c906c62afc3747ef9ecfcb45a9ccf984).
 
 You're encouraged to continue role circles with those who are playing the same role as you.

--- a/src/course/syllabus/developer/projects/in-house-build-2/schedule.md
+++ b/src/course/syllabus/developer/projects/in-house-build-2/schedule.md
@@ -26,7 +26,7 @@ schedule:
     - name: Role circles
       start: 12:45
       end: 13:00
-      url: /course/handbook/role-circles
+      url: https://foundersandcoders.notion.site/Role-circles-a2371aab24f34955a69904b87ffc1f05
     - name: Build
       start: 14:00
       end: 16:00
@@ -37,7 +37,7 @@ schedule:
     - name: Team code review
       start: 16:15
       end: 17:45
-      url: /course/handbook/code-review/
+      url: https://foundersandcoders.notion.site/Code-Reviews-5c3b987ed1204e46b4c738da538a758c
   wednesday:
     - name: Web Science
       start: 10:00
@@ -58,15 +58,13 @@ schedule:
     - name: Sprint Review
       start: 10:15
       end: 11:45
-      url: /course/handbook/project-docs/sprint-planning
     - start: 11:45
       end: 13:00
       name: Presentation prep
-      url: /course/handbook/project-presentations/
+      url: https://foundersandcoders.notion.site/In-House-Project-Presentation-e1936ce95a8041b9b8a93e5d4f638ff6
     - name: Project documentation
       start: 15:30
       end: 16:00
-      url: /course/handbook/project-documentation/
   friday:
     - name: Progress Log Review
       start: 10:00

--- a/src/course/syllabus/developer/projects/in-house-build-2/spikes.md
+++ b/src/course/syllabus/developer/projects/in-house-build-2/spikes.md
@@ -2,6 +2,6 @@
 
 There are no defined spikes for this week.
 
-You may find that you need to manage spikes within your sprints. Remember to follow [the techniques you followed earlier in the programme](/course/handbook/spikes).
+You may find that you need to manage spikes within your sprints. Remember to follow [the techniques you followed earlier in the programme](https://foundersandcoders.notion.site/Tech-Spikes-c906c62afc3747ef9ecfcb45a9ccf984).
 
 You're encouraged to continue role circles with those who are playing the same role as you.

--- a/src/course/syllabus/developer/projects/in-house-design/resources.md
+++ b/src/course/syllabus/developer/projects/in-house-design/resources.md
@@ -3,4 +3,4 @@
 - [Sprint by Google Venture](https://www.gv.com/sprint/)
 - [The Design Sprint](https://www.thesprintbook.com/the-design-sprint)
 - [Design Sprint Methodologies](https://designsprintkit.withgoogle.com/methodology/overview)
-- [User Research & Usability Testing](/course/handbook/project-docs/user-research/)
+- User Research & Usability Testing

--- a/src/course/syllabus/developer/projects/in-house-design/schedule.md
+++ b/src/course/syllabus/developer/projects/in-house-design/schedule.md
@@ -28,7 +28,6 @@ schedule:
     - name: Conduct user research
       start: 14:15
       end: 15:45
-      url: https://learn.foundersandcoders.com/course/handbook/project-docs/user-research/
     - name: Break
       start: 15:45
       end: 16:00
@@ -93,7 +92,7 @@ schedule:
     - name: Introduction to project roles
       start: 17:30
       end: 17:35
-      url: /course/handbook/project-team
+      url: https://foundersandcoders.notion.site/Project-roles-c2be6c42f4fe4bb0911049b084c51791
       type: presentation
     - name: Choose roles
       start: 17:35
@@ -120,7 +119,6 @@ schedule:
     - name: Sprint planning
       start: 15:45
       end: 16:45
-      url: /course/handbook/project-docs/sprint-planning
     - start: 16:45
       end: 17:45
       name: Feedback Session
@@ -128,7 +126,6 @@ schedule:
     - name: Project documentation
       start: 9:45
       end: 10:30
-      url: /course/handbook/project-documentation/
     - name: Build
       start: 10:30
       end: 13:00

--- a/src/course/syllabus/tfb/week 12/resources.md
+++ b/src/course/syllabus/tfb/week 12/resources.md
@@ -1,7 +1,5 @@
 ## Further reading
 
-[Showcase prep](/course/handbook/project-docs/tfb-presentations/)
-
 - A guide to help you create an awesome presentation for your TfB showcase
 
 [Example Presentation](https://www.canva.com/design/DAFfPl9SWwY/Nr8jsUAAlKeApazjb_SNqg/edit?utm_content=DAFfPl9SWwY&utm_campaign=designshare&utm_medium=link2&utm_source=sharebutton)

--- a/src/workshops/node-npm-intro/index.md
+++ b/src/workshops/node-npm-intro/index.md
@@ -28,7 +28,7 @@ You'll need to have Node installed on your computer to follow this workshop. Che
 node --version
 ```
 
-You should see a version number printed. If you get an error that means Node isn't installed. Follow [our installation guide](/course/handbook/installation/#node) then try again.
+You should see a version number printed. If you get an error that means Node isn't installed. Follow [our installation guide](https://foundersandcoders.notion.site/Installation-Guide-879500e472964043a17a1ad886b0905b) then try again.
 
 Our programme relies on some features that were only added in Node version 18 (the current version), so if you have an older version than that you should install the newer one with:
 

--- a/src/workshops/scope-challenge/index.md
+++ b/src/workshops/scope-challenge/index.md
@@ -88,7 +88,7 @@ Generally you should always prefer `let` and `const`, since it can be confusing 
 1. You should see a JS error in the console.
 1. Fix this error, and every other error that shows up
 
-Don't worry about understanding all of the code, just try to make it work. This is mostly an exercise in [debugging](/course/handbook/debugging/), so keep persisting until the app works like [the solution](starter-files/solution/):
+Don't worry about understanding all of the code, just try to make it work. This is mostly an exercise in debugging, so keep persisting until the app works like [the solution](starter-files/solution/):
 
 <figure>
   <img src="https://user-images.githubusercontent.com/9408641/76011766-0a492200-5f0d-11ea-9d20-a8676725255d.gif" alt="Colourful circles appearing as I click on a web page">


### PR DESCRIPTION
Since the handbook is now being outsourced there are a number of outdated links in the ft schedule. I have tried to update all so that they link to the notion page.