### PR TITLE
Updated dates for spring term unschool dates

### DIFF
--- a/src/course/syllabus/foundation/pre-course/schedule.md
+++ b/src/course/syllabus/foundation/pre-course/schedule.md
@@ -1,9 +1,8 @@
 ### Spring Term unschool workshop dates:
 
-- Saturday 27th January
-- Saturday 17th February
-- Saturday 2nd March
-- Saturday 16th March
+- Saturday 6th April (Open AI Unschool)
+- Saturday 4th May (Dev Ops 1)
+- Saturday 18th May (Dev Ops 2)
 
 ***Students on the foundation programme are expected to attend all unschool workshops***
 


### PR DESCRIPTION
# Updated dates for Saturday unschools for spring term.
Closes #947

<img width="543" alt="Screenshot 2024-03-12 at 17 07 46" src="https://github.com/foundersandcoders/coursebook/assets/74174344/8b5b1b7a-e3df-44e0-a842-38ed94aad354">
