### PR TITLE
fix: `response.body` to `body`

### DIFF
--- a/src/learn/server/index.md
+++ b/src/learn/server/index.md
@@ -513,7 +513,7 @@ Run your tests again and you should see the first one fail, since it is still ex
 
 ```js
 // ...
-assert.match(response.body, /Hello/);
+assert.match(body, /Hello/);
 ```
 
 {% enddisclosure %}


### PR DESCRIPTION
Line 516 calls `response.body`. It should call `body`, which is equivalent to `response.text`. This caused 3 of us to get stuck at various times!