### PR TITLE
Stop workshop layouts getting squished

### DIFF
--- a/src/_includes/resources.11ty.js
+++ b/src/_includes/resources.11ty.js
@@ -14,7 +14,7 @@ exports.data = {
 
 exports.render = ({ page: { url }, content }) => {
   return html`
-  <div class="layout">
+  <div>
     <aside></aside>
     <!-- <aside>
       <${Nav}>


### PR DESCRIPTION
On medium viewports the content column ends up way too small because of the empty space left for the (nonexistent) sidebar nav.

Workshops don't have a sidebar, so we can just not use this layout for them.

This is a quick fix so the content is no longer centre-aligned, but I think that's fine as it's way more usable for people with medium screens.

## Before

https://github.com/foundersandcoders/coursebook/assets/9408641/643fe3cc-39b0-4cb2-8fa8-7111bdd461b4

## After

https://github.com/foundersandcoders/coursebook/assets/9408641/5901fd0d-fc06-4449-8e34-ab5d6b24a32c
